### PR TITLE
fix: Twitter access and button loading

### DIFF
--- a/src/components/Connection/ConnectionOption/ConnectionOption.tsx
+++ b/src/components/Connection/ConnectionOption/ConnectionOption.tsx
@@ -21,7 +21,9 @@ export const ConnectionOption = (props: ConnectionIconProps): JSX.Element => {
           disabled={disabled}
           loading={loading}
         >
-          <div role="img" aria-label={type} className={classNames(styles.icon, styles[`icon-${type}`], styles.primaryImage)} />
+          {!loading ? (
+            <div role="img" aria-label={type} className={classNames(styles.icon, styles[`icon-${type}`], styles.primaryImage)} />
+          ) : null}
           {children}
         </Button>
       }

--- a/src/components/Pages/LoginPage/utils.ts
+++ b/src/components/Pages/LoginPage/utils.ts
@@ -66,7 +66,7 @@ export async function connectToProvider(connectionOption: ConnectionOptionType):
     url.pathname = '/auth/callback'
 
     await magic.oauth.loginWithRedirect({
-      provider: connectionOption as OAuthProvider,
+      provider: connectionOption === ConnectionOptionType.X ? 'twitter' : (connectionOption as OAuthProvider),
       redirectURI: url.href
     })
   }


### PR DESCRIPTION
This PR does the following:
- Fixes the Twitter access problem by changing the name of the connection from X to twitter when performing the connection.
- Removes the connection icon when loading the connection option so the loader is visible.