### PR TITLE
fix: Disable MetaMask if not installed

### DIFF
--- a/src/components/Connection/Connection.module.css
+++ b/src/components/Connection/Connection.module.css
@@ -101,6 +101,6 @@
   width: 100%;
 }
 
-.secondaryOptionButton:global(.ui.button.primary) {
+.secondaryOptionButton span :global(.ui.button.primary) {
   min-width: 104px;
 }

--- a/src/components/Connection/Connection.spec.tsx
+++ b/src/components/Connection/Connection.spec.tsx
@@ -28,6 +28,11 @@ function renderConnection(props: Partial<ConnectionProps>) {
   )
 }
 
+;(window.ethereum as any) = {
+  ...window.ethereum,
+  isMetaMask: true
+}
+
 let screen: ReturnType<typeof renderConnection>
 
 describe('when rendering the component', () => {
@@ -102,6 +107,59 @@ describe('when rendering the component', () => {
     })
   })
 
+  describe('and the user has metamask installed', () => {
+    let oldEthereum: typeof window.ethereum
+
+    beforeEach(() => {
+      oldEthereum = window.ethereum
+      ;(window.ethereum as any) = {
+        ...window.ethereum,
+        isMetaMask: true
+      }
+      web3Options = {
+        primary: ConnectionOptionType.METAMASK,
+        secondary: [ConnectionOptionType.FORTMATIC, ConnectionOptionType.WALLET_CONNECT, ConnectionOptionType.COINBASE]
+      }
+      onConnect = jest.fn()
+      screen = renderConnection({ web3Options, onConnect })
+    })
+
+    afterEach(() => {
+      window.ethereum = oldEthereum
+    })
+
+    it('should call the onConnect method prop when clicking the button', () => {
+      const { getByTestId } = screen
+      fireEvent.click(getByTestId(`${WEB3_PRIMARY_TEST_ID}-${ConnectionOptionType.METAMASK}-button`))
+      expect(onConnect).toHaveBeenCalledWith(ConnectionOptionType.METAMASK)
+    })
+  })
+
+  describe('and the user does not have metamask installed', () => {
+    let oldEthereum: typeof window.ethereum
+
+    beforeEach(() => {
+      oldEthereum = window.ethereum
+      window.ethereum = undefined
+      web3Options = {
+        primary: ConnectionOptionType.METAMASK,
+        secondary: [ConnectionOptionType.FORTMATIC, ConnectionOptionType.WALLET_CONNECT, ConnectionOptionType.COINBASE]
+      }
+      onConnect = jest.fn()
+      screen = renderConnection({ web3Options, onConnect })
+    })
+
+    afterEach(() => {
+      window.ethereum = oldEthereum
+    })
+
+    it('should not call the onConnect method prop when clicking the button', () => {
+      const { getByTestId } = screen
+      fireEvent.click(getByTestId(`${WEB3_PRIMARY_TEST_ID}-${ConnectionOptionType.METAMASK}-button`))
+      expect(onConnect).not.toHaveBeenCalled()
+    })
+  })
+
   describe('and there are web3 options', () => {
     beforeEach(() => {
       onConnect = jest.fn()
@@ -115,12 +173,6 @@ describe('when rendering the component', () => {
     it('should render the primary social option', () => {
       const { getByTestId } = screen
       expect(getByTestId(WEB3_PRIMARY_TEST_ID)).toBeInTheDocument()
-    })
-
-    it('should call the onConnect method prop when clicking the button', () => {
-      const { getByTestId } = screen
-      fireEvent.click(getByTestId(`${WEB3_PRIMARY_TEST_ID}-${ConnectionOptionType.METAMASK}-button`))
-      expect(onConnect).toHaveBeenCalledWith(ConnectionOptionType.METAMASK)
     })
 
     it('should render all the secondary options', () => {

--- a/src/components/Connection/Connection.tsx
+++ b/src/components/Connection/Connection.tsx
@@ -11,10 +11,8 @@ import {
   WEB3_PRIMARY_TEST_ID,
   WEB3_SECONDARY_TEST_ID
 } from './constants'
-import { ConnectionOptionType, ConnectionProps } from './Connection.types'
+import { ConnectionOptionType, ConnectionProps, MetamaskEthereumWindow } from './Connection.types'
 import styles from './Connection.module.css'
-
-type MetamaskEthereumWindow = typeof window.ethereum & { isMetaMask?: boolean }
 
 const Primary = ({
   message,
@@ -101,7 +99,6 @@ export const Connection = (props: ConnectionProps): JSX.Element => {
   }, [showMore])
 
   const isMetamaskAvailable = (window.ethereum as MetamaskEthereumWindow)?.isMetaMask
-
   const hasSocialSecondaryOptions = socialOptions && socialOptions.secondary && socialOptions.secondary.length > 0
   const hasWeb3SecondaryOptions = web3Options && web3Options.secondary && web3Options.secondary.length > 0
 
@@ -136,7 +133,7 @@ export const Connection = (props: ConnectionProps): JSX.Element => {
             option={web3Options?.primary}
             loadingOption={loadingOption}
             error={
-              !isMetamaskAvailable
+              !isMetamaskAvailable && web3Options?.primary === ConnectionOptionType.METAMASK
                 ? 'You need to install the MetaMask Browser Extension to proceed. Please install it and try again.'
                 : undefined
             }

--- a/src/components/Connection/Connection.tsx
+++ b/src/components/Connection/Connection.tsx
@@ -14,27 +14,33 @@ import {
 import { ConnectionOptionType, ConnectionProps } from './Connection.types'
 import styles from './Connection.module.css'
 
+type MetamaskEthereumWindow = typeof window.ethereum & { isMetaMask?: boolean }
+
 const Primary = ({
   message,
   children,
   option,
   testId,
   loadingOption,
+  error,
   onConnect
 }: {
   message: React.ReactNode
   children: React.ReactChild
   option: ConnectionOptionType
   loadingOption?: ConnectionOptionType
+  error?: string
   testId?: string
   onConnect: (wallet: ConnectionOptionType) => unknown
 }) => (
   <div className={styles.primary} data-testid={testId}>
     <div className={styles.primaryMessage}>{message}</div>
     <ConnectionOption
-      disabled={!!loadingOption}
+      disabled={!!loadingOption || !!error}
       loading={loadingOption === option}
+      showTooltip={!!error}
       type={option}
+      info={error}
       onClick={onConnect}
       className={classNames(styles.primaryButton, styles.primaryOption)}
       testId={testId}
@@ -94,6 +100,8 @@ export const Connection = (props: ConnectionProps): JSX.Element => {
     setShowMore(!showMore)
   }, [showMore])
 
+  const isMetamaskAvailable = (window.ethereum as MetamaskEthereumWindow)?.isMetaMask
+
   const hasSocialSecondaryOptions = socialOptions && socialOptions.secondary && socialOptions.secondary.length > 0
   const hasWeb3SecondaryOptions = web3Options && web3Options.secondary && web3Options.secondary.length > 0
 
@@ -127,6 +135,11 @@ export const Connection = (props: ConnectionProps): JSX.Element => {
             testId={WEB3_PRIMARY_TEST_ID}
             option={web3Options?.primary}
             loadingOption={loadingOption}
+            error={
+              !isMetamaskAvailable
+                ? 'You need to install the MetaMask Browser Extension to proceed. Please install it and try again.'
+                : undefined
+            }
             message={i18n.web3Message(element => (
               <span className={styles.primaryLearnMore} role="button" onClick={() => onLearnMore(web3Options.primary)}>
                 {element}

--- a/src/components/Connection/Connection.types.ts
+++ b/src/components/Connection/Connection.types.ts
@@ -13,6 +13,8 @@ export enum ConnectionOptionType {
   X = 'x'
 }
 
+export type MetamaskEthereumWindow = typeof window.ethereum & { isMetaMask?: boolean }
+
 export type ConnectionI18N = {
   title: React.ReactNode
   subtitle: React.ReactNode

--- a/src/components/Connection/ConnectionOption/ConnectionOption.tsx
+++ b/src/components/Connection/ConnectionOption/ConnectionOption.tsx
@@ -6,29 +6,31 @@ import { ConnectionIconProps } from './ConnectionOption.types'
 import styles from './ConnectionOption.module.css'
 
 export const ConnectionOption = (props: ConnectionIconProps): JSX.Element => {
-  const { className, children, type, testId, showTooltip, tooltipPosition, disabled, loading, onClick } = props
+  const { className, children, type, testId, showTooltip, tooltipPosition, disabled, info, loading, onClick } = props
   return (
     <Popup
       position={showTooltip && tooltipPosition ? tooltipPosition : 'top center'}
       disabled={!showTooltip}
       trigger={
-        <Button
-          primary
-          key={type}
-          size="small"
-          data-testid={`${testId}-${type}-button`}
-          className={classNames(className, styles.button)}
-          onClick={() => onClick(type)}
-          disabled={disabled}
-          loading={loading}
-        >
-          {!loading ? (
-            <div role="img" aria-label={type} className={classNames(styles.icon, styles[`icon-${type}`], styles.primaryImage)} />
-          ) : null}
-          {children}
-        </Button>
+        <span>
+          <Button
+            primary
+            key={type}
+            size="small"
+            data-testid={`${testId}-${type}-button`}
+            className={classNames(className, styles.button)}
+            onClick={() => onClick(type)}
+            disabled={disabled}
+            loading={loading}
+          >
+            {!loading ? (
+              <div role="img" aria-label={type} className={classNames(styles.icon, styles[`icon-${type}`], styles.primaryImage)} />
+            ) : null}
+            {children}
+          </Button>
+        </span>
       }
-      content={capitalize(type)}
+      content={info ?? capitalize(type)}
       on="hover"
     />
   )

--- a/src/components/Connection/ConnectionOption/ConnectionOption.types.ts
+++ b/src/components/Connection/ConnectionOption/ConnectionOption.types.ts
@@ -4,6 +4,7 @@ import { ConnectionOptionType } from '../Connection.types'
 export type ConnectionIconProps = {
   type: ConnectionOptionType
   className?: string
+  info?: string
   showTooltip?: boolean
   testId?: string
   tooltipPosition?: PopupProps['position']

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -277,7 +277,7 @@ export const RequestPage = () => {
               <Icon name="discord" />
               <p className={styles.discordInfo}>
                 <span>Need guidance?</span>
-                <span>MEET THE COMMUNITY</span>
+                <span>ASK THE COMMUNITY</span>
               </p>
             </a>
           </div>


### PR DESCRIPTION
If the MetaMask extension is not installed, disable the MetaMask button and show a message.

![Screenshot 2024-01-18 at 11 26 40](https://github.com/decentraland/auth/assets/1120791/d332f45e-b5a3-482c-a193-801f6b89720b)
