### PR TITLE
fix: If the user does not have a profile created, redirect to setup page

### DIFF
--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -65,6 +65,19 @@ export const RequestPage = () => {
         // Try to restablish connection with the wallet.
         const connectionData = await connection.tryPreviousConnection()
         providerRef.current = new ethers.BrowserProvider(connectionData.provider)
+
+        // Goes to the login page if no account is returned in the data.
+        if (!connectionData.account) {
+          throw new Error('No account connected')
+        }
+
+        const profile = await fetchProfile(connectionData.account)
+
+        // Goes to the setup page if the connected account does not have a profile yet.
+        if (!profile) {
+          navigate(`/setup?redirectTo=/auth/requests/${requestId}`)
+          return
+        }
       } catch (e) {
         toLoginPage()
         return


### PR DESCRIPTION
Fixes the issue in which if you tried to connect to the desktop client but you were already connected with the wallet to decentraland.org, it would not make you setup your profile.

Added some comments with things we should take in consideration in a future refactor. 

This change is just to fix the current issue.