### PR TITLE
feat: Add invalid redirection page

### DIFF
--- a/src/components/Pages/DefaultPage/DefaultPage.tsx
+++ b/src/components/Pages/DefaultPage/DefaultPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { Loader } from 'decentraland-ui/dist/components/Loader/Loader'
 import { connection } from 'decentraland-connect'
+import { locations } from '../../../shared/locations'
 import styles from './DefaultPage.module.css'
 
 export const DefaultPage = () => {
@@ -19,9 +20,9 @@ export const DefaultPage = () => {
   useEffect(() => {
     checkIfConnected().then(isConnected => {
       if (isConnected) {
-        window.location.href = '/'
+        window.location.href = locations.home()
       } else {
-        navigate({ pathname: '/login', search: location.search })
+        navigate({ pathname: locations.login(), search: location.search })
       }
     })
   }, [checkIfConnected, navigate])

--- a/src/components/Pages/InvalidRedirectionPage/InvalidRedirectionPage.module.css
+++ b/src/components/Pages/InvalidRedirectionPage/InvalidRedirectionPage.module.css
@@ -1,0 +1,11 @@
+.warningImage {
+  height: 64px;
+  width: 64px;
+  margin-bottom: 24px;
+}
+
+:global(.ui.modal>.content).content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/src/components/Pages/InvalidRedirectionPage/InvalidRedirectionPage.tsx
+++ b/src/components/Pages/InvalidRedirectionPage/InvalidRedirectionPage.tsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom'
+import { Button } from 'decentraland-ui/dist/components/Button/Button'
+import { Modal } from 'decentraland-ui/dist/components/Modal/Modal'
+import { ModalNavigation } from 'decentraland-ui/dist/components/ModalNavigation/ModalNavigation'
+import warningSrc from '../../../assets/images/warning.svg'
+import { locations } from '../../../shared/locations'
+import style from './InvalidRedirectionPage.module.css'
+
+export const InvalidRedirectionPage = () => {
+  return (
+    <Modal size="tiny" open={true}>
+      <ModalNavigation title="Invalid redirection" onClose={undefined} />
+      <Modal.Content className={style.content}>
+        <img className={style.warningImage} src={warningSrc} />
+        <p>The site you were redirected to is invalid.</p>
+      </Modal.Content>
+      <Modal.Actions>
+        <Button primary as={Link} to={locations.login()}>
+          Go back to the login page
+        </Button>
+      </Modal.Actions>
+    </Modal>
+  )
+}

--- a/src/components/Pages/InvalidRedirectionPage/index.ts
+++ b/src/components/Pages/InvalidRedirectionPage/index.ts
@@ -1,0 +1,1 @@
+export * from './InvalidRedirectionPage'

--- a/src/components/Pages/LoginPage/LoginPage.tsx
+++ b/src/components/Pages/LoginPage/LoginPage.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useMemo, useEffect, useContext } from 'react'
-import { useSearchParams } from 'react-router-dom'
 import Image1 from '../../../assets/images/background/image1.webp'
 import Image10 from '../../../assets/images/background/image10.webp'
 import Image2 from '../../../assets/images/background/image2.webp'
@@ -10,6 +9,7 @@ import Image6 from '../../../assets/images/background/image6.webp'
 import Image7 from '../../../assets/images/background/image7.webp'
 import Image8 from '../../../assets/images/background/image8.webp'
 import Image9 from '../../../assets/images/background/image9.webp'
+import { useNavigateWithSearchParams } from '../../../hooks/navigation'
 import { useAfterLoginRedirection } from '../../../hooks/redirection'
 import { useTargetConfig } from '../../../hooks/targetConfig'
 import usePageTracking from '../../../hooks/usePageTracking'
@@ -17,6 +17,7 @@ import { getAnalytics } from '../../../modules/analytics/segment'
 import { ClickEvents, ConnectionType, TrackingEvents } from '../../../modules/analytics/types'
 import { fetchProfile } from '../../../modules/profile'
 import { isErrorWithMessage } from '../../../shared/errors'
+import { locations } from '../../../shared/locations'
 import { wait } from '../../../shared/time'
 import { Connection, ConnectionOptionType } from '../../Connection'
 import { ConnectionModal, ConnectionModalState } from '../../ConnectionModal'
@@ -30,14 +31,14 @@ const BACKGROUND_IMAGES = [Image1, Image2, Image3, Image4, Image5, Image6, Image
 
 export const LoginPage = () => {
   usePageTracking()
-  const [searchParams] = useSearchParams()
+  const navigate = useNavigateWithSearchParams()
   const [connectionModalState, setConnectionModalState] = useState(ConnectionModalState.CONNECTING_WALLET)
   const [showLearnMore, setShowLearnMore] = useState(false)
   const [showMagicLearnMore, setShowMagicLearnMore] = useState(false)
   const [showConnectionModal, setShowConnectionModal] = useState(false)
   const [currentConnectionType, setCurrentConnectionType] = useState<ConnectionOptionType>()
   const [isMobile] = useState(getIsMobile())
-  const redirectTo = useAfterLoginRedirection()
+  const { url: redirectTo, redirect } = useAfterLoginRedirection()
   const showGuestOption = redirectTo && new URL(redirectTo).pathname.includes('/play')
   const [currentBackgroundIndex, setCurrentBackgroundIndex] = useState(0)
   const { flags } = useContext(FeatureFlagsContext)
@@ -126,22 +127,13 @@ export const LoginPage = () => {
               // If the connected account does not have a profile, redirect the user to the setup page to create a new one.
               // The setup page should then redirect the user to the url provided as query param if available.
               if (!profile) {
-                window.location.href = '/auth/setup' + (redirectTo ? `?redirectTo=${redirectTo}` : '')
-                setShowConnectionModal(false)
-                return
+                navigate(locations.setup(redirectTo))
+                return setShowConnectionModal(false)
               }
             }
           }
 
-          if (redirectTo) {
-            // If a redirection url was provided in the query params, redirect the user to that url.
-            window.location.href = redirectTo
-          } else {
-            // Redirect the user to the root url if there is no other place to redirect.
-            // TODO: Maybe we should add something to the root page, or simply redirect to the profile app.
-            window.location.href = '/'
-          }
-
+          redirect()
           setShowConnectionModal(false)
         } catch (error) {
           console.log('Error', JSON.stringify(error))
@@ -150,7 +142,7 @@ export const LoginPage = () => {
         }
       }
     },
-    [setConnectionModalState, setShowConnectionModal, setCurrentConnectionType, redirectTo, searchParams, flags]
+    [setConnectionModalState, setShowConnectionModal, setCurrentConnectionType, redirectTo, navigate, redirect, flags]
   )
 
   const handleOnCloseConnectionModal = useCallback(() => {

--- a/src/hooks/navigation.ts
+++ b/src/hooks/navigation.ts
@@ -1,0 +1,20 @@
+import { useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+export const useNavigateWithSearchParams = () => {
+  const navigate = useNavigate()
+  const enhancedNavigation = useCallback(
+    (path: string) => {
+      const urlFromPath = new URL(path, window.location.origin)
+      const search = urlFromPath.search
+      if (search) {
+        navigate({ pathname: path, search: search })
+      } else {
+        navigate(path)
+      }
+    },
+    [navigate]
+  )
+
+  return enhancedNavigation
+}

--- a/src/hooks/redirection.spec.ts
+++ b/src/hooks/redirection.spec.ts
@@ -16,9 +16,9 @@ describe('when using the redirection hook', () => {
       mockedUseLocation.mockReturnValue({ search: '' } as Location)
     })
 
-    it('should return undefined', () => {
+    it('should return the default site', () => {
       const { result } = renderHook(() => useAfterLoginRedirection())
-      expect(result.current).toBeUndefined()
+      expect(result.current.url).toBe('http://localhost/')
     })
   })
 
@@ -27,9 +27,9 @@ describe('when using the redirection hook', () => {
       mockedUseLocation.mockReturnValue({ search: 'redirectTo=https://test.com' } as Location)
     })
 
-    it('should return undefined', () => {
+    it('should return the invalid redirection URL', () => {
       const { result } = renderHook(() => useAfterLoginRedirection())
-      expect(result.current).toBeUndefined()
+      expect(result.current.url).toBe('http://localhost/auth/invalidRedirection')
     })
   })
 
@@ -40,7 +40,7 @@ describe('when using the redirection hook', () => {
 
     it('should return the local path using the current domain', () => {
       const { result } = renderHook(() => useAfterLoginRedirection())
-      expect(result.current).toBe('http://localhost/test')
+      expect(result.current.url).toBe('http://localhost/test')
     })
   })
 
@@ -51,7 +51,7 @@ describe('when using the redirection hook', () => {
 
     it('should return the local path using the current domain', () => {
       const { result } = renderHook(() => useAfterLoginRedirection())
-      expect(result.current).toBe('http://localhost/test')
+      expect(result.current.url).toBe('http://localhost/test')
     })
   })
 
@@ -60,9 +60,9 @@ describe('when using the redirection hook', () => {
       mockedUseLocation.mockReturnValue({ search: 'redirectTo=//test.com' } as Location)
     })
 
-    it('should return undefined', () => {
+    it('should return the invalid redirection URL', () => {
       const { result } = renderHook(() => useAfterLoginRedirection())
-      expect(result.current).toBeUndefined()
+      expect(result.current.url).toBe('http://localhost/auth/invalidRedirection')
     })
   })
 
@@ -71,9 +71,9 @@ describe('when using the redirection hook', () => {
       mockedUseLocation.mockReturnValue({ search: 'redirectTo=%2F%2Ftest.com' } as Location)
     })
 
-    it('should return undefined', () => {
+    it('should return the invalid redirection URL', () => {
       const { result } = renderHook(() => useAfterLoginRedirection())
-      expect(result.current).toBeUndefined()
+      expect(result.current.url).toBe('http://localhost/auth/invalidRedirection')
     })
   })
 
@@ -82,9 +82,9 @@ describe('when using the redirection hook', () => {
       mockedUseLocation.mockReturnValue({ search: 'redirectTo=%252F%252Ftest.com' } as Location)
     })
 
-    it('should return undefined', () => {
+    it('should return the invalid redirection URL', () => {
       const { result } = renderHook(() => useAfterLoginRedirection())
-      expect(result.current).toBeUndefined()
+      expect(result.current.url).toBe('http://localhost/auth/invalidRedirection')
     })
   })
 
@@ -95,7 +95,7 @@ describe('when using the redirection hook', () => {
 
     it('should return the local path using the current domain', () => {
       const { result } = renderHook(() => useAfterLoginRedirection())
-      expect(result.current).toBe('http://localhost/@test.com')
+      expect(result.current.url).toBe('http://localhost/@test.com')
     })
   })
 
@@ -104,9 +104,9 @@ describe('when using the redirection hook', () => {
       mockedUseLocation.mockReturnValue({ search: 'redirectTo=https://test.com/@localhost' } as Location)
     })
 
-    it('should return undefined', () => {
+    it('should return the invalid redirection URL', () => {
       const { result } = renderHook(() => useAfterLoginRedirection())
-      expect(result.current).toBeUndefined()
+      expect(result.current.url).toBe('http://localhost/auth/invalidRedirection')
     })
   })
 
@@ -115,9 +115,9 @@ describe('when using the redirection hook', () => {
       mockedUseLocation.mockReturnValue({ search: 'redirectTo=https://example.com%5C%5C@localhost' } as Location)
     })
 
-    it('should return undefined', () => {
+    it('should return the invalid redirection URL', () => {
       const { result } = renderHook(() => useAfterLoginRedirection())
-      expect(result.current).toBeUndefined()
+      expect(result.current.url).toBe('http://localhost/auth/invalidRedirection')
     })
   })
 
@@ -128,7 +128,7 @@ describe('when using the redirection hook', () => {
 
     it('should return the URL', () => {
       const { result } = renderHook(() => useAfterLoginRedirection())
-      expect(result.current).toBe('http://localhost/test')
+      expect(result.current.url).toBe('http://localhost/test')
     })
   })
 })

--- a/src/hooks/redirection.ts
+++ b/src/hooks/redirection.ts
@@ -1,14 +1,14 @@
+import { useCallback } from 'react'
 import { useLocation } from 'react-router-dom'
+import { locations } from '../shared/locations'
 
 export const useAfterLoginRedirection = () => {
   const location = useLocation()
   const search = new URLSearchParams(location.search)
   const redirectToSearchParam = search.get('redirectTo')
-  const redirectTo = redirectToSearchParam ? decodeURIComponent(redirectToSearchParam) : null
+  const redirectTo = redirectToSearchParam ? decodeURIComponent(redirectToSearchParam) : locations.home()
 
-  if (redirectTo === null) {
-    return undefined
-  }
+  let sanitizedRedirectTo: string = locations.home()
 
   try {
     let redirectToURL: URL
@@ -20,12 +20,17 @@ export const useAfterLoginRedirection = () => {
     }
 
     if (redirectToURL.hostname !== window.location.hostname) {
-      return undefined
+      redirectToURL = new URL('/auth/invalidRedirection', window.location.origin)
     }
 
-    return redirectToURL.href
+    sanitizedRedirectTo = redirectToURL.href
   } catch (error) {
     console.error("Can't parse redirectTo URL")
-    return undefined
   }
+
+  const redirect = useCallback(() => {
+    window.location.href = sanitizedRedirectTo
+  }, [sanitizedRedirectTo])
+
+  return { url: sanitizedRedirectTo, redirect }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import { RequestPage } from './components/Pages/RequestPage'
 import { SetupPage } from './components/Pages/SetupPage'
 import { DefaultPage } from './components/Pages/DefaultPage'
 import { CallbackPage } from './components/Pages/CallbackPage'
+import { InvalidRedirectionPage } from './components/Pages/InvalidRedirectionPage'
 import { LoginPage } from './components/Pages/LoginPage'
 import { FeatureFlagsProvider } from './components/FeatureFlagsProvider'
 import { config } from './modules/config'
@@ -24,6 +25,7 @@ ReactDOM.render(
       <BrowserRouter basename="/auth">
         <Routes>
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/invalidRedirection" element={<InvalidRedirectionPage />} />
           <Route path="/callback" element={<CallbackPage />} />
           <Route path="/requests/:requestId" element={<RequestPage />} />
           <Route path="/setup" element={<SetupPage />} />

--- a/src/shared/locations.ts
+++ b/src/shared/locations.ts
@@ -1,0 +1,5 @@
+export const locations = {
+  home: () => '/',
+  login: (redirectTo?: string) => `/login${redirectTo ? `redirectTo=${encodeURIComponent(redirectTo)}` : ''}`,
+  setup: (redirectTo?: string) => `/setup${redirectTo ? `redirectTo=${encodeURIComponent(redirectTo)}` : ''}`
+}


### PR DESCRIPTION
This changes how redirection works by:
- Adding the redirect function to execute the redirection from the `redirectTo` parameter.
- Changing most of the local redirections from `window.location.href` changes to `navigate`.
- Changing the redirection hook to point to an invalid path when the `redirectTo` parameter is invalid.
- Adding the InvalidRedirectionPage component so it shows users when they've been redirected through an invalid `redirectTo` parameter.