### PR TITLE
feat: add target configs for multiple platforms, add deep links and refactor social connection list

### DIFF
--- a/src/components/Connection/Connection.spec.tsx
+++ b/src/components/Connection/Connection.spec.tsx
@@ -1,12 +1,6 @@
 import { act, fireEvent, render } from '@testing-library/react'
 import { Connection } from './Connection'
-import {
-  SHOW_MORE_BUTTON_TEST_ID,
-  SOCIAL_PRIMARY_TEST_ID,
-  SOCIAL_SECONDARY_TEST_ID,
-  WEB3_PRIMARY_TEST_ID,
-  WEB3_SECONDARY_TEST_ID
-} from './constants'
+import { EXTRA_TEST_ID, PRIMARY_TEST_ID, SHOW_MORE_BUTTON_TEST_ID } from './constants'
 import { ConnectionOptionType, ConnectionProps } from './Connection.types'
 
 function renderConnection(props: Partial<ConnectionProps>) {
@@ -36,40 +30,28 @@ function renderConnection(props: Partial<ConnectionProps>) {
 let screen: ReturnType<typeof renderConnection>
 
 describe('when rendering the component', () => {
-  let socialOptions: ConnectionProps['socialOptions'] | undefined
-  let web3Options: ConnectionProps['web3Options'] | undefined
+  let connectionOptions: ConnectionProps['connectionOptions']
   let onConnect: jest.Mock
-
-  describe('and there are no social options', () => {
-    beforeEach(() => {
-      socialOptions = undefined
-      screen = renderConnection({ socialOptions })
-    })
-
-    it('should not render the primary social option', () => {
-      const { queryByTestId } = screen
-      expect(queryByTestId(SOCIAL_PRIMARY_TEST_ID)).not.toBeInTheDocument()
-    })
-  })
 
   describe('and there are social options', () => {
     beforeEach(() => {
       onConnect = jest.fn()
-      socialOptions = {
+      connectionOptions = {
         primary: ConnectionOptionType.GOOGLE,
-        secondary: [ConnectionOptionType.APPLE, ConnectionOptionType.X, ConnectionOptionType.DISCORD]
+        secondary: ConnectionOptionType.APPLE,
+        extraOptions: [ConnectionOptionType.X, ConnectionOptionType.DISCORD]
       }
-      screen = renderConnection({ socialOptions, onConnect })
+      screen = renderConnection({ connectionOptions, onConnect })
     })
 
     it('should render the primary social option', () => {
       const { getByTestId } = screen
-      expect(getByTestId(SOCIAL_PRIMARY_TEST_ID)).toBeInTheDocument()
+      expect(getByTestId(PRIMARY_TEST_ID)).toBeInTheDocument()
     })
 
     it('should call the onConnect method prop when clicking the button', () => {
       const { getByTestId } = screen
-      fireEvent.click(getByTestId(`${SOCIAL_PRIMARY_TEST_ID}-${ConnectionOptionType.GOOGLE}-button`))
+      fireEvent.click(getByTestId(`${PRIMARY_TEST_ID}-${ConnectionOptionType.GOOGLE}-button`))
       expect(onConnect).toHaveBeenCalledWith(ConnectionOptionType.GOOGLE)
     })
 
@@ -78,8 +60,8 @@ describe('when rendering the component', () => {
       act(() => {
         fireEvent.click(getByTestId(SHOW_MORE_BUTTON_TEST_ID))
       })
-      socialOptions?.secondary.forEach(option => {
-        expect(getByTestId(`${SOCIAL_SECONDARY_TEST_ID}-${option}-button`)).toBeInTheDocument()
+      connectionOptions?.extraOptions?.forEach(option => {
+        expect(getByTestId(`${EXTRA_TEST_ID}-${option}-button`)).toBeInTheDocument()
       })
     })
 
@@ -88,22 +70,10 @@ describe('when rendering the component', () => {
       act(() => {
         fireEvent.click(getByTestId(SHOW_MORE_BUTTON_TEST_ID))
       })
-      socialOptions?.secondary.forEach(option => {
-        fireEvent.click(getByTestId(`${SOCIAL_SECONDARY_TEST_ID}-${option}-button`))
+      connectionOptions?.extraOptions?.forEach(option => {
+        fireEvent.click(getByTestId(`${EXTRA_TEST_ID}-${option}-button`))
         expect(onConnect).toHaveBeenCalledWith(option)
       })
-    })
-  })
-
-  describe('and there are no primary web3 options', () => {
-    beforeEach(() => {
-      socialOptions = undefined
-      screen = renderConnection({ socialOptions })
-    })
-
-    it('should not render the primary web3 option', () => {
-      const { queryByTestId } = screen
-      expect(queryByTestId(WEB3_PRIMARY_TEST_ID)).not.toBeInTheDocument()
     })
   })
 
@@ -116,12 +86,12 @@ describe('when rendering the component', () => {
         ...window.ethereum,
         isMetaMask: true
       }
-      web3Options = {
+      connectionOptions = {
         primary: ConnectionOptionType.METAMASK,
-        secondary: [ConnectionOptionType.FORTMATIC, ConnectionOptionType.WALLET_CONNECT, ConnectionOptionType.COINBASE]
+        extraOptions: [ConnectionOptionType.FORTMATIC, ConnectionOptionType.WALLET_CONNECT, ConnectionOptionType.COINBASE]
       }
       onConnect = jest.fn()
-      screen = renderConnection({ web3Options, onConnect })
+      screen = renderConnection({ connectionOptions, onConnect })
     })
 
     afterEach(() => {
@@ -130,7 +100,7 @@ describe('when rendering the component', () => {
 
     it('should call the onConnect method prop when clicking the button', () => {
       const { getByTestId } = screen
-      fireEvent.click(getByTestId(`${WEB3_PRIMARY_TEST_ID}-${ConnectionOptionType.METAMASK}-button`))
+      fireEvent.click(getByTestId(`${PRIMARY_TEST_ID}-${ConnectionOptionType.METAMASK}-button`))
       expect(onConnect).toHaveBeenCalledWith(ConnectionOptionType.METAMASK)
     })
   })
@@ -141,12 +111,12 @@ describe('when rendering the component', () => {
     beforeEach(() => {
       oldEthereum = window.ethereum
       window.ethereum = undefined
-      web3Options = {
+      connectionOptions = {
         primary: ConnectionOptionType.METAMASK,
-        secondary: [ConnectionOptionType.FORTMATIC, ConnectionOptionType.WALLET_CONNECT, ConnectionOptionType.COINBASE]
+        extraOptions: [ConnectionOptionType.FORTMATIC, ConnectionOptionType.WALLET_CONNECT, ConnectionOptionType.COINBASE]
       }
       onConnect = jest.fn()
-      screen = renderConnection({ web3Options, onConnect })
+      screen = renderConnection({ connectionOptions, onConnect })
     })
 
     afterEach(() => {
@@ -155,7 +125,7 @@ describe('when rendering the component', () => {
 
     it('should not call the onConnect method prop when clicking the button', () => {
       const { getByTestId } = screen
-      fireEvent.click(getByTestId(`${WEB3_PRIMARY_TEST_ID}-${ConnectionOptionType.METAMASK}-button`))
+      fireEvent.click(getByTestId(`${PRIMARY_TEST_ID}-${ConnectionOptionType.METAMASK}-button`))
       expect(onConnect).not.toHaveBeenCalled()
     })
   })
@@ -163,16 +133,16 @@ describe('when rendering the component', () => {
   describe('and there are web3 options', () => {
     beforeEach(() => {
       onConnect = jest.fn()
-      web3Options = {
+      connectionOptions = {
         primary: ConnectionOptionType.METAMASK,
-        secondary: [ConnectionOptionType.FORTMATIC, ConnectionOptionType.WALLET_CONNECT, ConnectionOptionType.COINBASE]
+        extraOptions: [ConnectionOptionType.FORTMATIC, ConnectionOptionType.WALLET_CONNECT, ConnectionOptionType.COINBASE]
       }
-      screen = renderConnection({ web3Options, onConnect })
+      screen = renderConnection({ connectionOptions, onConnect })
     })
 
     it('should render the primary social option', () => {
       const { getByTestId } = screen
-      expect(getByTestId(WEB3_PRIMARY_TEST_ID)).toBeInTheDocument()
+      expect(getByTestId(PRIMARY_TEST_ID)).toBeInTheDocument()
     })
 
     it('should render all the secondary options', () => {
@@ -180,8 +150,8 @@ describe('when rendering the component', () => {
       act(() => {
         fireEvent.click(getByTestId(SHOW_MORE_BUTTON_TEST_ID))
       })
-      web3Options?.secondary.forEach(option => {
-        expect(getByTestId(`${WEB3_SECONDARY_TEST_ID}-${option}-button`)).toBeInTheDocument()
+      connectionOptions?.extraOptions?.forEach(option => {
+        expect(getByTestId(`${EXTRA_TEST_ID}-${option}-button`)).toBeInTheDocument()
       })
     })
 
@@ -190,8 +160,8 @@ describe('when rendering the component', () => {
       act(() => {
         fireEvent.click(getByTestId(SHOW_MORE_BUTTON_TEST_ID))
       })
-      web3Options?.secondary.forEach(option => {
-        fireEvent.click(getByTestId(`${WEB3_SECONDARY_TEST_ID}-${option}-button`))
+      connectionOptions?.extraOptions?.forEach(option => {
+        fireEvent.click(getByTestId(`${EXTRA_TEST_ID}-${option}-button`))
         expect(onConnect).toHaveBeenCalledWith(option)
       })
     })
@@ -199,9 +169,8 @@ describe('when rendering the component', () => {
 
   describe('and there are no web3 nor social secondary options', () => {
     beforeEach(() => {
-      socialOptions = undefined
-      web3Options = undefined
-      screen = renderConnection({ socialOptions, web3Options })
+      connectionOptions = undefined
+      screen = renderConnection({ connectionOptions })
     })
 
     it('should not render the more options button', () => {

--- a/src/components/Connection/Connection.spec.tsx
+++ b/src/components/Connection/Connection.spec.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render } from '@testing-library/react'
 import { Connection } from './Connection'
-import { EXTRA_TEST_ID, PRIMARY_TEST_ID, SHOW_MORE_BUTTON_TEST_ID } from './constants'
+import { EXTRA_TEST_ID, PRIMARY_TEST_ID, SECONDARY_TEST_ID, SHOW_MORE_BUTTON_TEST_ID } from './constants'
 import { ConnectionOptionType, ConnectionProps } from './Connection.types'
 
 function renderConnection(props: Partial<ConnectionProps>) {
@@ -33,7 +33,7 @@ describe('when rendering the component', () => {
   let connectionOptions: ConnectionProps['connectionOptions']
   let onConnect: jest.Mock
 
-  describe('and there are social options', () => {
+  describe('and there are primary, secondary and extra options', () => {
     beforeEach(() => {
       onConnect = jest.fn()
       connectionOptions = {
@@ -44,9 +44,10 @@ describe('when rendering the component', () => {
       screen = renderConnection({ connectionOptions, onConnect })
     })
 
-    it('should render the primary social option', () => {
+    it('should render the primary and secondary option', () => {
       const { getByTestId } = screen
       expect(getByTestId(PRIMARY_TEST_ID)).toBeInTheDocument()
+      expect(getByTestId(SECONDARY_TEST_ID)).toBeInTheDocument()
     })
 
     it('should call the onConnect method prop when clicking the button', () => {
@@ -55,7 +56,7 @@ describe('when rendering the component', () => {
       expect(onConnect).toHaveBeenCalledWith(ConnectionOptionType.GOOGLE)
     })
 
-    it('should render all the secondary options', () => {
+    it('should render all the extra options', () => {
       const { getByTestId } = screen
       act(() => {
         fireEvent.click(getByTestId(SHOW_MORE_BUTTON_TEST_ID))
@@ -130,7 +131,7 @@ describe('when rendering the component', () => {
     })
   })
 
-  describe('and there are web3 options', () => {
+  describe('and there are is not secondary options', () => {
     beforeEach(() => {
       onConnect = jest.fn()
       connectionOptions = {
@@ -140,12 +141,17 @@ describe('when rendering the component', () => {
       screen = renderConnection({ connectionOptions, onConnect })
     })
 
-    it('should render the primary social option', () => {
+    it('should render the primary option', () => {
       const { getByTestId } = screen
       expect(getByTestId(PRIMARY_TEST_ID)).toBeInTheDocument()
     })
 
-    it('should render all the secondary options', () => {
+    it('should not render the secondary', () => {
+      const { queryByTestId } = screen
+      expect(queryByTestId(SECONDARY_TEST_ID)).not.toBeInTheDocument()
+    })
+
+    it('should render all the extra options', () => {
       const { getByTestId } = screen
       act(() => {
         fireEvent.click(getByTestId(SHOW_MORE_BUTTON_TEST_ID))
@@ -167,7 +173,31 @@ describe('when rendering the component', () => {
     })
   })
 
-  describe('and there are no web3 nor social secondary options', () => {
+  describe('and there are primary, but not secondary nor extra options', () => {
+    beforeEach(() => {
+      connectionOptions = {
+        primary: ConnectionOptionType.METAMASK
+      }
+      screen = renderConnection({ connectionOptions })
+    })
+
+    it('should render the primary', () => {
+      const { queryByTestId } = screen
+      expect(queryByTestId(PRIMARY_TEST_ID)).toBeInTheDocument()
+    })
+
+    it('should not render the secondary', () => {
+      const { queryByTestId } = screen
+      expect(queryByTestId(SECONDARY_TEST_ID)).not.toBeInTheDocument()
+    })
+
+    it('should not render the more options button', () => {
+      const { queryByTestId } = screen
+      expect(queryByTestId(SHOW_MORE_BUTTON_TEST_ID)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('and there are no primary nor secondary nor extra options', () => {
     beforeEach(() => {
       connectionOptions = undefined
       screen = renderConnection({ connectionOptions })

--- a/src/components/Connection/Connection.tsx
+++ b/src/components/Connection/Connection.tsx
@@ -4,14 +4,14 @@ import Icon from 'semantic-ui-react/dist/commonjs/elements/Icon/Icon'
 import { Button } from 'decentraland-ui/dist/components/Button/Button'
 import logoSrc from '../../assets/images/logo.svg'
 import { ConnectionOption } from './ConnectionOption'
+import { EXTRA_TEST_ID, PRIMARY_TEST_ID, SECONDARY_TEST_ID, SHOW_MORE_BUTTON_TEST_ID } from './constants'
 import {
-  SHOW_MORE_BUTTON_TEST_ID,
-  SOCIAL_PRIMARY_TEST_ID,
-  SOCIAL_SECONDARY_TEST_ID,
-  WEB3_PRIMARY_TEST_ID,
-  WEB3_SECONDARY_TEST_ID
-} from './constants'
-import { ConnectionOptionType, ConnectionProps, MetamaskEthereumWindow, connectionOptionTitles } from './Connection.types'
+  ConnectionOptionType,
+  ConnectionProps,
+  MetamaskEthereumWindow,
+  connectionOptionTitles,
+  isMagicConnection
+} from './Connection.types'
 import styles from './Connection.module.css'
 
 const Primary = ({
@@ -91,7 +91,7 @@ const defaultProps = {
 }
 
 export const Connection = (props: ConnectionProps): JSX.Element => {
-  const { i18n = defaultProps.i18n, onConnect, onLearnMore, socialOptions, web3Options, className, loadingOption } = props
+  const { i18n = defaultProps.i18n, onConnect, onLearnMore, connectionOptions, className, loadingOption } = props
 
   const [showMore, setShowMore] = useState(false)
   const handleShowMore = useCallback(() => {
@@ -99,8 +99,39 @@ export const Connection = (props: ConnectionProps): JSX.Element => {
   }, [showMore])
 
   const isMetamaskAvailable = (window.ethereum as MetamaskEthereumWindow)?.isMetaMask
-  const hasSocialSecondaryOptions = socialOptions && socialOptions.secondary && socialOptions.secondary.length > 0
-  const hasWeb3SecondaryOptions = web3Options && web3Options.secondary && web3Options.secondary.length > 0
+  const hasExtraOptions = connectionOptions?.extraOptions && connectionOptions.extraOptions.length > 0
+
+  const renderPrimary = (option: ConnectionOptionType, testId: string) => (
+    <Primary
+      onConnect={onConnect}
+      testId={testId}
+      option={option}
+      loadingOption={loadingOption}
+      error={
+        !isMetamaskAvailable && option === ConnectionOptionType.METAMASK
+          ? 'You need to install the MetaMask Browser Extension to proceed. Please install it and try again.'
+          : undefined
+      }
+      message={
+        isMagicConnection(option) ? (
+          <>
+            {i18n.socialMessage(<div className={styles.primaryMagic} role="img" aria-label="Magic" />)}
+            <span className={styles.primaryLearnMore} role="button" onClick={() => onLearnMore(option)}>
+              Learn More
+            </span>
+          </>
+        ) : (
+          i18n.web3Message(element => (
+            <span className={styles.primaryLearnMore} role="button" onClick={() => onLearnMore(option)}>
+              {element}
+            </span>
+          ))
+        )
+      }
+    >
+      <>{isMagicConnection(option) ? i18n.accessWith(option) : i18n.connectWith(option)}</>
+    </Primary>
+  )
 
   return (
     <div className={classNames(className, styles.connection)}>
@@ -108,48 +139,12 @@ export const Connection = (props: ConnectionProps): JSX.Element => {
       <div>
         <h1 className={styles.title}>{i18n.title}</h1>
         <h2 className={styles.subtitle}>{i18n.subtitle}</h2>
-        {socialOptions ? (
-          <Primary
-            onConnect={onConnect}
-            testId={SOCIAL_PRIMARY_TEST_ID}
-            option={socialOptions?.primary}
-            loadingOption={loadingOption}
-            message={
-              <>
-                {i18n.socialMessage(<div className={styles.primaryMagic} role="img" aria-label="Magic" />)}
-                <span className={styles.primaryLearnMore} role="button" onClick={() => onLearnMore(socialOptions?.primary)}>
-                  Learn More
-                </span>
-              </>
-            }
-          >
-            <>{i18n.accessWith(socialOptions?.primary)}</>
-          </Primary>
-        ) : null}
-        {web3Options ? (
-          <Primary
-            onConnect={onConnect}
-            testId={WEB3_PRIMARY_TEST_ID}
-            option={web3Options?.primary}
-            loadingOption={loadingOption}
-            error={
-              !isMetamaskAvailable && web3Options?.primary === ConnectionOptionType.METAMASK
-                ? 'You need to install the MetaMask Browser Extension to proceed. Please install it and try again.'
-                : undefined
-            }
-            message={i18n.web3Message(element => (
-              <span className={styles.primaryLearnMore} role="button" onClick={() => onLearnMore(web3Options.primary)}>
-                {element}
-              </span>
-            ))}
-          >
-            <>{i18n.connectWith(web3Options?.primary)}</>
-          </Primary>
-        ) : null}
+        {connectionOptions && renderPrimary(connectionOptions.primary, PRIMARY_TEST_ID)}
+        {connectionOptions?.secondary && renderPrimary(connectionOptions.secondary, SECONDARY_TEST_ID)}
       </div>
 
       <div className={styles.showMore}>
-        {(hasWeb3SecondaryOptions || hasSocialSecondaryOptions) && (
+        {hasExtraOptions && (
           <Button
             data-testid={SHOW_MORE_BUTTON_TEST_ID}
             basic
@@ -162,21 +157,12 @@ export const Connection = (props: ConnectionProps): JSX.Element => {
             <Icon name={showMore ? 'chevron up' : 'chevron down'} />
           </Button>
         )}
-        {showMore && hasSocialSecondaryOptions && (
+        {showMore && hasExtraOptions && connectionOptions.extraOptions && (
           <Secondary
-            testId={SOCIAL_SECONDARY_TEST_ID}
-            options={socialOptions.secondary}
+            testId={EXTRA_TEST_ID}
+            options={connectionOptions.extraOptions}
             onConnect={onConnect}
             tooltipDirection="top center"
-            loadingOption={loadingOption}
-          />
-        )}
-        {showMore && hasWeb3SecondaryOptions && (
-          <Secondary
-            testId={WEB3_SECONDARY_TEST_ID}
-            options={web3Options.secondary}
-            onConnect={onConnect}
-            tooltipDirection="bottom center"
             loadingOption={loadingOption}
           />
         )}

--- a/src/components/Connection/Connection.tsx
+++ b/src/components/Connection/Connection.tsx
@@ -10,9 +10,9 @@ import {
   ConnectionProps,
   MetamaskEthereumWindow,
   connectionOptionTitles,
-  isMagicConnection
 } from './Connection.types'
 import styles from './Connection.module.css'
+import { isSocialLogin } from '../Pages/LoginPage/utils'
 
 const Primary = ({
   message,
@@ -113,7 +113,7 @@ export const Connection = (props: ConnectionProps): JSX.Element => {
           : undefined
       }
       message={
-        isMagicConnection(option) ? (
+        isSocialLogin(option) ? (
           <>
             {i18n.socialMessage(<div className={styles.primaryMagic} role="img" aria-label="Magic" />)}
             <span className={styles.primaryLearnMore} role="button" onClick={() => onLearnMore(option)}>
@@ -129,7 +129,7 @@ export const Connection = (props: ConnectionProps): JSX.Element => {
         )
       }
     >
-      <>{isMagicConnection(option) ? i18n.accessWith(option) : i18n.connectWith(option)}</>
+      <>{isSocialLogin(option) ? i18n.accessWith(option) : i18n.connectWith(option)}</>
     </Primary>
   )
 

--- a/src/components/Connection/Connection.types.ts
+++ b/src/components/Connection/Connection.types.ts
@@ -28,6 +28,15 @@ export const connectionOptionTitles: { [key in ConnectionOptionType]: string } =
   [ConnectionOptionType.X]: 'X'
 }
 
+export function isMagicConnection(option: ConnectionOptionType): boolean {
+  return (
+    option === ConnectionOptionType.X ||
+    option === ConnectionOptionType.APPLE ||
+    option === ConnectionOptionType.GOOGLE ||
+    option === ConnectionOptionType.DISCORD
+  )
+}
+
 export type MetamaskEthereumWindow = typeof window.ethereum & { isMetaMask?: boolean }
 
 export type ConnectionI18N = {
@@ -42,13 +51,10 @@ export type ConnectionI18N = {
 
 export type ConnectionProps = {
   i18n?: ConnectionI18N
-  socialOptions?: {
+  connectionOptions?: {
     primary: ConnectionOptionType
-    secondary: ConnectionOptionType[]
-  }
-  web3Options?: {
-    primary: ConnectionOptionType
-    secondary: ConnectionOptionType[]
+    secondary?: ConnectionOptionType
+    extraOptions?: ConnectionOptionType[]
   }
   className?: string
   loadingOption?: ConnectionOptionType

--- a/src/components/Connection/Connection.types.ts
+++ b/src/components/Connection/Connection.types.ts
@@ -28,15 +28,6 @@ export const connectionOptionTitles: { [key in ConnectionOptionType]: string } =
   [ConnectionOptionType.X]: 'X'
 }
 
-export function isMagicConnection(option: ConnectionOptionType): boolean {
-  return (
-    option === ConnectionOptionType.X ||
-    option === ConnectionOptionType.APPLE ||
-    option === ConnectionOptionType.GOOGLE ||
-    option === ConnectionOptionType.DISCORD
-  )
-}
-
 export type MetamaskEthereumWindow = typeof window.ethereum & { isMetaMask?: boolean }
 
 export type ConnectionI18N = {

--- a/src/components/Connection/constants.ts
+++ b/src/components/Connection/constants.ts
@@ -1,5 +1,4 @@
-export const SOCIAL_PRIMARY_TEST_ID = 'social-primary-test-id'
-export const SOCIAL_SECONDARY_TEST_ID = 'social-secondary-test-id'
-export const WEB3_PRIMARY_TEST_ID = 'web3-primary-test-id'
-export const WEB3_SECONDARY_TEST_ID = 'web3-secondary-test-id'
+export const PRIMARY_TEST_ID = 'primary-test-id'
+export const SECONDARY_TEST_ID = 'secondary-test-id'
+export const EXTRA_TEST_ID = 'extra-options-test-id'
 export const SHOW_MORE_BUTTON_TEST_ID = 'show-more-button-test-id'

--- a/src/components/Pages/LoginPage/LoginPage.tsx
+++ b/src/components/Pages/LoginPage/LoginPage.tsx
@@ -24,7 +24,7 @@ import { ConnectionModal, ConnectionModalState } from '../../ConnectionModal'
 import { FeatureFlagsContext } from '../../FeatureFlagsProvider'
 import { MagicInformationModal } from '../../MagicInformationModal'
 import { WalletInformationModal } from '../../WalletInformationModal'
-import { getIdentitySignature, connectToProvider, isSocialLogin, fromConnectionOptionToProviderType, getIsMobile } from './utils'
+import { getIdentitySignature, connectToProvider, isSocialLogin, fromConnectionOptionToProviderType } from './utils'
 import styles from './LoginPage.module.css'
 
 const BACKGROUND_IMAGES = [Image1, Image2, Image3, Image4, Image5, Image6, Image7, Image8, Image9, Image10]
@@ -37,7 +37,6 @@ export const LoginPage = () => {
   const [showMagicLearnMore, setShowMagicLearnMore] = useState(false)
   const [showConnectionModal, setShowConnectionModal] = useState(false)
   const [currentConnectionType, setCurrentConnectionType] = useState<ConnectionOptionType>()
-  const [isMobile] = useState(getIsMobile())
   const { url: redirectTo, redirect } = useAfterLoginRedirection()
   const showGuestOption = redirectTo && new URL(redirectTo).pathname.includes('/play')
   const [currentBackgroundIndex, setCurrentBackgroundIndex] = useState(0)
@@ -193,21 +192,7 @@ export const LoginPage = () => {
             onLearnMore={handleLearnMore}
             onConnect={handleOnConnect}
             loadingOption={currentConnectionType}
-            socialOptions={{
-              primary: ConnectionOptionType.GOOGLE,
-              secondary: [ConnectionOptionType.DISCORD, ConnectionOptionType.APPLE, ConnectionOptionType.X]
-            }}
-            web3Options={
-              isMobile
-                ? {
-                    primary: ConnectionOptionType.WALLET_CONNECT,
-                    secondary: [ConnectionOptionType.FORTMATIC, ConnectionOptionType.COINBASE]
-                  }
-                : {
-                    primary: ConnectionOptionType.METAMASK,
-                    secondary: [ConnectionOptionType.FORTMATIC, ConnectionOptionType.COINBASE, ConnectionOptionType.WALLET_CONNECT]
-                  }
-            }
+            connectionOptions={targetConfig.connectionOptions}
           />
           {showGuestOption && (
             <div className={styles.guestInfo}>

--- a/src/components/Pages/LoginPage/utils.ts
+++ b/src/components/Pages/LoginPage/utils.ts
@@ -106,7 +106,7 @@ export async function getIdentitySignature(address: string, provider: Provider):
   return identity
 }
 
-export function getIsMobile() {
+export function isMobile() {
   const userAgent = navigator.userAgent
   return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(userAgent)
 }

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -54,7 +54,7 @@ export const RequestPage = () => {
   const timeoutRef = useRef<NodeJS.Timeout>()
   const connectedAccountRef = useRef<string>()
   const requestId = params.requestId ?? ''
-  const [targetConfig] = useTargetConfig()
+  const [targetConfig, targetConfigId] = useTargetConfig()
 
   // Goes to the login page where the user will have to connect a wallet.
   const toLoginPage = useCallback(() => {

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -54,7 +54,7 @@ export const RequestPage = () => {
   const timeoutRef = useRef<NodeJS.Timeout>()
   const connectedAccountRef = useRef<string>()
   const requestId = params.requestId ?? ''
-  const [targetConfig, targetConfigId] = useTargetConfig()
+  const [targetConfig] = useTargetConfig()
 
   // Goes to the login page where the user will have to connect a wallet.
   const toLoginPage = useCallback(() => {
@@ -185,6 +185,10 @@ export const RequestPage = () => {
         throw new Error(result.error)
       } else {
         setView(View.VERIFY_SIGN_IN_COMPLETE)
+
+        if (targetConfig.deepLink) {
+          window.location.href = targetConfig.deepLink
+        }
       }
     } catch (e) {
       setError(isErrorWithMessage(e) ? e.message : 'Unknown error')

--- a/src/hooks/targetConfig.spec.ts
+++ b/src/hooks/targetConfig.spec.ts
@@ -1,0 +1,76 @@
+import { useLocation } from 'react-router-dom'
+import { renderHook } from '@testing-library/react-hooks'
+import { ConnectionOptionType } from '../components/Connection'
+import { isMobile } from '../components/Pages/LoginPage/utils'
+import { _targetConfigs, useTargetConfig } from './targetConfig'
+
+jest.mock('react-router-dom')
+jest.mock('../components/Pages/LoginPage/utils')
+
+describe('useTargetConfig', () => {
+  const mockLocation = { search: '' }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useLocation as jest.Mock).mockReturnValue(mockLocation)
+  })
+
+  it('returns default config when no targetConfigId is provided', () => {
+    ;(isMobile as jest.Mock).mockReturnValue(false)
+
+    const { result } = renderHook(() => useTargetConfig())
+    const [config, targetConfigId] = result.current
+
+    expect(targetConfigId).toBe('default')
+    expect(config).toEqual(_targetConfigs.default)
+  })
+
+  it('returns ios config when targetConfigId=ios', () => {
+    ;(useLocation as jest.Mock).mockReturnValue({ search: '?targetConfigId=ios' })
+    ;(isMobile as jest.Mock).mockReturnValue(false)
+
+    const { result } = renderHook(() => useTargetConfig())
+    const [config, targetConfigId] = result.current
+
+    expect(targetConfigId).toBe('ios')
+    expect(config).toEqual(_targetConfigs.ios)
+  })
+
+  it('returns the mobile-adjusted config for default config on mobile', () => {
+    ;(useLocation as jest.Mock).mockReturnValue({ search: '?targetConfigId=default' })
+    ;(isMobile as jest.Mock).mockReturnValue(true)
+
+    const { result } = renderHook(() => useTargetConfig())
+    const [config] = result.current
+
+    expect(config.connectionOptions.primary).toBe(ConnectionOptionType.GOOGLE)
+    expect(config.connectionOptions.secondary).toBe(ConnectionOptionType.WALLET_CONNECT)
+    expect(config.connectionOptions.extraOptions).not.toContain(ConnectionOptionType.WALLET_CONNECT)
+    expect(config.connectionOptions.extraOptions).not.toContain(ConnectionOptionType.METAMASK)
+  })
+
+  it('applies mobile adjustments for all targetConfigId configurations', () => {
+    ;(useLocation as jest.Mock).mockReturnValue({ search: '?targetConfigId=alternative' })
+    ;(isMobile as jest.Mock).mockReturnValue(true)
+
+    const { result } = renderHook(() => useTargetConfig())
+    const [config, targetConfigId] = result.current
+
+    expect(targetConfigId).toBe('alternative')
+    expect(config.connectionOptions.primary).toBe(ConnectionOptionType.GOOGLE)
+    expect(config.connectionOptions.secondary).toBe(ConnectionOptionType.WALLET_CONNECT)
+    expect(config.connectionOptions.extraOptions).not.toContain(ConnectionOptionType.WALLET_CONNECT)
+    expect(config.connectionOptions.extraOptions).not.toContain(ConnectionOptionType.METAMASK)
+  })
+
+  it('returns default config when an invalid targetConfigId is provided', () => {
+    ;(useLocation as jest.Mock).mockReturnValue({ search: '?targetConfigId=invalid' })
+    ;(isMobile as jest.Mock).mockReturnValue(false)
+
+    const { result } = renderHook(() => useTargetConfig())
+    const [config, targetConfigId] = result.current
+
+    expect(targetConfigId).toBe('default')
+    expect(config).toEqual(_targetConfigs.default)
+  })
+})

--- a/src/hooks/targetConfig.spec.ts
+++ b/src/hooks/targetConfig.spec.ts
@@ -36,6 +36,39 @@ describe('useTargetConfig', () => {
     expect(config).toEqual(_targetConfigs.ios)
   })
 
+  it('returns android config when targetConfigId=android', () => {
+    ;(useLocation as jest.Mock).mockReturnValue({ search: '?targetConfigId=android' })
+    ;(isMobile as jest.Mock).mockReturnValue(false)
+
+    const { result } = renderHook(() => useTargetConfig())
+    const [config, targetConfigId] = result.current
+
+    expect(targetConfigId).toBe('android')
+    expect(config).toEqual(_targetConfigs.android)
+  })
+
+  it('returns androidSocial config when targetConfigId=androidSocial', () => {
+    ;(useLocation as jest.Mock).mockReturnValue({ search: '?targetConfigId=androidSocial' })
+    ;(isMobile as jest.Mock).mockReturnValue(false)
+
+    const { result } = renderHook(() => useTargetConfig())
+    const [config, targetConfigId] = result.current
+
+    expect(targetConfigId).toBe('androidSocial')
+    expect(config).toEqual(_targetConfigs.androidSocial)
+  })
+
+  it('returns androidWeb3 config when targetConfigId=androidWeb3', () => {
+    ;(useLocation as jest.Mock).mockReturnValue({ search: '?targetConfigId=androidWeb3' })
+    ;(isMobile as jest.Mock).mockReturnValue(false)
+
+    const { result } = renderHook(() => useTargetConfig())
+    const [config, targetConfigId] = result.current
+
+    expect(targetConfigId).toBe('androidWeb3')
+    expect(config).toEqual(_targetConfigs.androidWeb3)
+  })
+
   it('returns the mobile-adjusted config for default config on mobile', () => {
     ;(useLocation as jest.Mock).mockReturnValue({ search: '?targetConfigId=default' })
     ;(isMobile as jest.Mock).mockReturnValue(true)

--- a/src/hooks/targetConfig.ts
+++ b/src/hooks/targetConfig.ts
@@ -1,30 +1,148 @@
-import { useLocation } from 'react-router-dom'
+import { useLocation, Location } from 'react-router-dom'
+import { ConnectionOptionType } from '../components/Connection'
+import { isMobile } from '../components/Pages/LoginPage/utils'
 
-type TargetConfigId = 'default' | 'alternative'
+type TargetConfigId = 'default' | 'alternative' | 'ios' | 'android' | 'androidSocial' | 'androidWeb3'
+
+type ConnectionOptions = {
+  primary: ConnectionOptionType
+  secondary?: ConnectionOptionType
+  extraOptions?: ConnectionOptionType[]
+}
+
 type TargetConfig = {
   skipSetup: boolean
   showWearablePreview: boolean
   explorerText: string
+  connectionOptions: ConnectionOptions
+  deepLink?: string
 }
 
-const targetConfigRecord: Record<TargetConfigId, TargetConfig> = {
+const defaultConfig: TargetConfig = {
+  skipSetup: false,
+  showWearablePreview: true,
+  explorerText: 'Desktop App',
+  connectionOptions: {
+    primary: ConnectionOptionType.GOOGLE,
+    secondary: ConnectionOptionType.METAMASK,
+    extraOptions: [
+      ConnectionOptionType.DISCORD,
+      ConnectionOptionType.APPLE,
+      ConnectionOptionType.X,
+      ConnectionOptionType.FORTMATIC,
+      ConnectionOptionType.COINBASE,
+      ConnectionOptionType.WALLET_CONNECT
+    ]
+  }
+}
+
+const targetConfigs: Record<TargetConfigId, TargetConfig> = {
   default: {
-    skipSetup: false,
-    showWearablePreview: true,
-    explorerText: 'Desktop App'
+    ...defaultConfig
   },
   alternative: {
+    ...defaultConfig,
     skipSetup: true,
     showWearablePreview: false,
     explorerText: 'Explorer'
+  },
+  ios: {
+    ...defaultConfig,
+    skipSetup: true,
+    showWearablePreview: false,
+    explorerText: 'Mobile App',
+    connectionOptions: {
+      primary: ConnectionOptionType.APPLE,
+      secondary: ConnectionOptionType.WALLET_CONNECT,
+      extraOptions: [
+        ConnectionOptionType.GOOGLE,
+        ConnectionOptionType.DISCORD,
+        ConnectionOptionType.X,
+        ConnectionOptionType.FORTMATIC,
+        ConnectionOptionType.COINBASE
+      ]
+    },
+    deepLink: 'decentraland://'
+  },
+  android: {
+    ...defaultConfig,
+    skipSetup: true,
+    showWearablePreview: false,
+    explorerText: 'Mobile App',
+    connectionOptions: {
+      primary: ConnectionOptionType.GOOGLE,
+      secondary: ConnectionOptionType.WALLET_CONNECT,
+      extraOptions: [
+        ConnectionOptionType.DISCORD,
+        ConnectionOptionType.APPLE,
+        ConnectionOptionType.X,
+        ConnectionOptionType.FORTMATIC,
+        ConnectionOptionType.COINBASE
+      ]
+    },
+    deepLink: 'decentraland://'
+  },
+  androidSocial: {
+    ...defaultConfig,
+    skipSetup: true,
+    showWearablePreview: false,
+    explorerText: 'Mobile App',
+    connectionOptions: {
+      primary: ConnectionOptionType.GOOGLE,
+      secondary: ConnectionOptionType.X,
+      extraOptions: [ConnectionOptionType.APPLE, ConnectionOptionType.DISCORD]
+    },
+    deepLink: 'decentraland://'
+  },
+  androidWeb3: {
+    ...defaultConfig,
+    skipSetup: true,
+    showWearablePreview: false,
+    explorerText: 'Mobile App',
+    connectionOptions: {
+      primary: ConnectionOptionType.WALLET_CONNECT
+    },
+    deepLink: 'decentraland://'
   }
+} as const
+
+const adjustWeb3OptionsForMobile = (config: TargetConfig): TargetConfig => {
+  let { primary, secondary, extraOptions } = config.connectionOptions
+
+  // Replace Metamask Extension for Wallet Connect on Mobile
+  if (primary === ConnectionOptionType.METAMASK) {
+    primary = ConnectionOptionType.WALLET_CONNECT
+    extraOptions = extraOptions?.filter(option => option !== ConnectionOptionType.WALLET_CONNECT)
+  }
+
+  if (secondary === ConnectionOptionType.METAMASK) {
+    secondary = ConnectionOptionType.WALLET_CONNECT
+    extraOptions = extraOptions?.filter(option => option !== ConnectionOptionType.WALLET_CONNECT)
+  }
+
+  extraOptions = extraOptions?.filter(option => option !== ConnectionOptionType.METAMASK)
+
+  return {
+    ...config,
+    connectionOptions: { primary, secondary, extraOptions }
+  }
+}
+
+// Exporting targetConfigs specifically for testing
+export const _targetConfigs = targetConfigs
+
+const getTargetConfigId = (location: Location): TargetConfigId => {
+  const search = new URLSearchParams(location.search)
+  const targetConfigIdParam = search.get('targetConfigId') as TargetConfigId
+  return targetConfigIdParam in targetConfigs ? targetConfigIdParam : 'default'
 }
 
 export const useTargetConfig = (): [TargetConfig, TargetConfigId] => {
   const location = useLocation()
-  const search = new URLSearchParams(location.search)
-  const targetConfigIdSearchParam = search.get('targetConfigId') || 'default'
-  const targetConfigId =
-    targetConfigIdSearchParam && targetConfigIdSearchParam in targetConfigRecord ? (targetConfigIdSearchParam as TargetConfigId) : 'default'
-  return [targetConfigRecord[targetConfigId], targetConfigId]
+  const targetConfigId = getTargetConfigId(location)
+  let config = targetConfigs[targetConfigId]
+  if (isMobile()) {
+    config = adjustWeb3OptionsForMobile(config)
+  }
+  return [config, targetConfigId]
 }

--- a/src/hooks/targetConfig.ts
+++ b/src/hooks/targetConfig.ts
@@ -36,6 +36,14 @@ const defaultConfig: TargetConfig = {
   }
 }
 
+const defaultMobileConfig: TargetConfig = {
+  ...defaultConfig,
+  skipSetup: true,
+  showWearablePreview: false,
+  explorerText: 'Mobile App',
+  deepLink: 'decentraland://'
+}
+
 const targetConfigs: Record<TargetConfigId, TargetConfig> = {
   default: {
     ...defaultConfig
@@ -47,10 +55,7 @@ const targetConfigs: Record<TargetConfigId, TargetConfig> = {
     explorerText: 'Explorer'
   },
   ios: {
-    ...defaultConfig,
-    skipSetup: true,
-    showWearablePreview: false,
-    explorerText: 'Mobile App',
+    ...defaultMobileConfig,
     connectionOptions: {
       primary: ConnectionOptionType.APPLE,
       secondary: ConnectionOptionType.WALLET_CONNECT,
@@ -61,14 +66,10 @@ const targetConfigs: Record<TargetConfigId, TargetConfig> = {
         ConnectionOptionType.FORTMATIC,
         ConnectionOptionType.COINBASE
       ]
-    },
-    deepLink: 'decentraland://'
+    }
   },
   android: {
-    ...defaultConfig,
-    skipSetup: true,
-    showWearablePreview: false,
-    explorerText: 'Mobile App',
+    ...defaultMobileConfig,
     connectionOptions: {
       primary: ConnectionOptionType.GOOGLE,
       secondary: ConnectionOptionType.WALLET_CONNECT,
@@ -79,30 +80,21 @@ const targetConfigs: Record<TargetConfigId, TargetConfig> = {
         ConnectionOptionType.FORTMATIC,
         ConnectionOptionType.COINBASE
       ]
-    },
-    deepLink: 'decentraland://'
+    }
   },
   androidSocial: {
-    ...defaultConfig,
-    skipSetup: true,
-    showWearablePreview: false,
-    explorerText: 'Mobile App',
+    ...defaultMobileConfig,
     connectionOptions: {
       primary: ConnectionOptionType.GOOGLE,
       secondary: ConnectionOptionType.X,
       extraOptions: [ConnectionOptionType.APPLE, ConnectionOptionType.DISCORD]
-    },
-    deepLink: 'decentraland://'
+    }
   },
   androidWeb3: {
-    ...defaultConfig,
-    skipSetup: true,
-    showWearablePreview: false,
-    explorerText: 'Mobile App',
+    ...defaultMobileConfig,
     connectionOptions: {
       primary: ConnectionOptionType.WALLET_CONNECT
-    },
-    deepLink: 'decentraland://'
+    }
   }
 }
 

--- a/src/hooks/targetConfig.ts
+++ b/src/hooks/targetConfig.ts
@@ -104,7 +104,7 @@ const targetConfigs: Record<TargetConfigId, TargetConfig> = {
     },
     deepLink: 'decentraland://'
   }
-} as const
+}
 
 const adjustWeb3OptionsForMobile = (config: TargetConfig): TargetConfig => {
   let { primary, secondary, extraOptions } = config.connectionOptions


### PR DESCRIPTION
### PR Summary

In our alternative explorer on Android and iOS platforms, we've updated our login methods to streamline the sign-in process and reduce the need to switch tabs when signing actions are required.

**Android:**
- We now use a WebView for Web3 login and a Chrome Custom Tab for social login, both optimized for secure credential handling.

**iOS:**
- We implemented WebKit for credential handling, as mandated by the Apple Review team during our app review process.

These features are secure since they leverage the official Android and iOS SDKs.

### Adaptations Needed on the `auth` Frontend

To support these changes, some modifications are required in the `auth` front. When using WebKit and Chrome Custom Tabs, we lose control on our end (`Explorer`) since the OS takes over the application's runtime. The only way to return to our app is via a `deep link`. This PR adds the option to include a `deep link` parameter, enabling a callback that directs users back to our app.

For example:
- When a `deep link` is provided, it opens a designated link, which is handled by a callback in our app. This is the standard way on Android and iOS to return users to the app.

### Trust Wallet Integration

Additionally, we are using WebView to open Trust Wallet, as it does not require credentials. Attempts to integrate Trust Wallet with Chrome Custom Tabs encountered limitations (e.g., changing the app closes the view). Therefore, for Wallet Connect logins, the target configuration will be set to `androidWeb3`. A new UI has been added to the mobile app to allow users to select the appropriate configuration.

### Summary of Changes

- [x] Added `ios`, `android`, `androidSocial`, and `androidWeb3` to `targetConfigIds`.
- [x] Added deep link support.
- [x] Refactored: Unified `web3Options` and `socialOptions` into a new `connectionOption` for simplicity.
