### PR TITLE
fix: Target config id not being propagated after signing in

### DIFF
--- a/src/shared/locations.ts
+++ b/src/shared/locations.ts
@@ -3,3 +3,35 @@ export const locations = {
   login: (redirectTo?: string) => `/login${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}`,
   setup: (redirectTo?: string) => `/setup${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}`
 }
+
+export const extractRedirectToFromSearchParameters = (searchParams: URLSearchParams): string => {
+  // Extract 'redirectTo' from current search parameters
+  let redirectToSearchParam = searchParams.get('redirectTo')
+  try {
+    const state = searchParams.get('state')
+    // Decode the state parameter to get the original 'redirectTo'
+    if (state) {
+      const stateRedirectToParam = atob(state)
+      const parsedRedirectTo = JSON.parse(stateRedirectToParam).customData
+      if (parsedRedirectTo) {
+        redirectToSearchParam = parsedRedirectTo ?? null
+      }
+    }
+  } catch (_) {
+    console.error("Can't decode state parameter")
+  }
+
+  // Initialize redirectTo with a default value
+  let redirectTo = locations.home()
+
+  // Decode 'redirectTo' if it exists
+  if (redirectToSearchParam) {
+    try {
+      redirectTo = decodeURIComponent(redirectToSearchParam)
+    } catch (error) {
+      console.error("Can't decode redirectTo parameter")
+    }
+  }
+
+  return redirectTo
+}


### PR DESCRIPTION
This PR adds the capability to retrieve the `targetConfigId` from the `redirectTo` parameter and to propagate it in the `redirectTo` parameter.