### PR TITLE
feat: Add more analytics to the auth site

### DIFF
--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -14,7 +14,7 @@ import { useNavigateWithSearchParams } from '../../../hooks/navigation'
 import { useTargetConfig } from '../../../hooks/targetConfig'
 import usePageTracking from '../../../hooks/usePageTracking'
 import { getAnalytics } from '../../../modules/analytics/segment'
-import { ClickEvents, TrackingEvents } from '../../../modules/analytics/types'
+import { ClickEvents, RequestInteractionType, TrackingEvents } from '../../../modules/analytics/types'
 import { config } from '../../../modules/config'
 import { fetchProfile } from '../../../modules/profile'
 import { getCurrentConnectionData } from '../../../shared/connection'
@@ -138,7 +138,8 @@ export const RequestPage = () => {
         // Show different views depending on the request method.
         if (request.method === 'dcl_personal_sign') {
           setView(View.VERIFY_SIGN_IN)
-          getAnalytics()?.track(TrackingEvents.VERIFY_SIGN_IN_REQUEST_TYPE, {
+          getAnalytics()?.track(TrackingEvents.REQUEST_INTERACTION, {
+            type: RequestInteractionType.VERIFY_SIGN_IN,
             browserTime: Date.now(),
             requestTime: new Date(request.expiration).getTime(),
             requestType: requestRef.current?.method
@@ -161,7 +162,8 @@ export const RequestPage = () => {
             setView(View.WALLET_INTERACTION)
           }
         } else {
-          getAnalytics()?.track(TrackingEvents.WALLET_INTERACTION_REQUEST_TYPE, {
+          getAnalytics()?.track(TrackingEvents.REQUEST_INTERACTION, {
+            type: RequestInteractionType.WALLET_INTERACTION,
             requestType: requestRef.current?.method
           })
           setView(View.WALLET_INTERACTION)

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -60,7 +60,7 @@ export const RequestPage = () => {
   const [isTransactionModalOpen, setIsTransactionModalOpen] = useState(false)
   // TODO: Add a type for the request.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const requestRef = useRef<any>()
+  const requestRef = useRef<{ method: string; params: any[]; code?: number }>()
   const [error, setError] = useState<string>()
   const timeoutRef = useRef<NodeJS.Timeout>()
   const connectedAccountRef = useRef<string>()
@@ -78,6 +78,8 @@ export const RequestPage = () => {
 
   useEffect(() => {
     const loadRequest = async () => {
+      const timeTheSiteStartedLoading = Date.now()
+
       try {
         // Try to re-stablish connection with the wallet.
         const connectionData = await getCurrentConnectionData()
@@ -126,11 +128,21 @@ export const RequestPage = () => {
 
         // Initialize the timeout to display the timeout view when the request expires.
         timeoutRef.current = setTimeout(() => {
+          getAnalytics()?.track(TrackingEvents.REQUEST_EXPIRED, {
+            browserTime: Date.now(),
+            requestTime: new Date(request.expiration).getTime(),
+            timeTheSiteStartedLoading
+          })
           setView(View.TIMEOUT)
         }, new Date(request.expiration).getTime() - Date.now())
         // Show different views depending on the request method.
         if (request.method === 'dcl_personal_sign') {
           setView(View.VERIFY_SIGN_IN)
+          getAnalytics()?.track(TrackingEvents.VERIFY_SIGN_IN_REQUEST_TYPE, {
+            browserTime: Date.now(),
+            requestTime: new Date(request.expiration).getTime(),
+            requestType: requestRef.current?.method
+          })
         } else if (request.method === 'eth_sendTransaction') {
           try {
             const signer = await providerRef.current.getSigner()
@@ -149,10 +161,18 @@ export const RequestPage = () => {
             setView(View.WALLET_INTERACTION)
           }
         } else {
+          getAnalytics()?.track(TrackingEvents.WALLET_INTERACTION_REQUEST_TYPE, {
+            requestType: requestRef.current?.method
+          })
           setView(View.WALLET_INTERACTION)
         }
       } catch (e) {
         setError(isErrorWithMessage(e) ? e.message : 'Unknown error')
+        getAnalytics()?.track(TrackingEvents.REQUEST_LOADING_ERROR, {
+          browserTime: Date.now(),
+          requestType: requestRef.current?.method,
+          timeTheSiteStartedLoading
+        })
         setView(View.LOADING_ERROR)
       }
     }
@@ -206,7 +226,7 @@ export const RequestPage = () => {
       }
 
       const signer = await provider.getSigner()
-      const signature = await signer.signMessage(requestRef.current.params[0])
+      const signature = await signer.signMessage(requestRef.current?.params[0])
       const result = await authServerFetch('outcome', {
         requestId,
         sender: await signer.getAddress(),
@@ -247,11 +267,15 @@ export const RequestPage = () => {
         throw new Error('Provider not created')
       }
 
+      if (!requestRef.current?.method) {
+        throw new Error('Method not found')
+      }
+
       const signer = await provider.getSigner()
-      const result = await provider.send(requestRef.current.method, requestRef.current.params)
+      const result = await provider.send(requestRef.current?.method, requestRef.current?.params)
       getAnalytics()?.track(TrackingEvents.CLICK, {
         action: ClickEvents.APPROVE_WALLET_INTERACTION,
-        method: requestRef.current.method
+        method: requestRef.current?.method
       })
       const fetchResult = await authServerFetch('outcome', {
         requestId,
@@ -421,7 +445,7 @@ export const RequestPage = () => {
         <div className={styles.logo}></div>
         <div className={styles.title}>Verify Sign In</div>
         <div className={styles.description}>Do you see the same verification number on your {targetConfig.explorerText}?</div>
-        <div className={styles.code}>{requestRef.current.code}</div>
+        <div className={styles.code}>{requestRef.current?.code}</div>
         <div className={styles.buttons}>
           <Button inverted disabled={isLoading} onClick={onDenyVerifySignIn} className={styles.noButton}>
             <Icon name="times circle" />

--- a/src/modules/analytics/types.ts
+++ b/src/modules/analytics/types.ts
@@ -7,8 +7,12 @@ export enum TrackingEvents {
   TERMS_OF_SERVICE_SUCCESS = 'Terms of service success',
   REQUEST_EXPIRED = 'Expired request',
   REQUEST_LOADING_ERROR = 'Error loading request',
-  WALLET_INTERACTION_REQUEST_TYPE = 'Wallet interaction request type',
-  VERIFY_SIGN_IN_REQUEST_TYPE = 'Verify sign in request type'
+  REQUEST_INTERACTION = 'Request interaction'
+}
+
+export enum RequestInteractionType {
+  VERIFY_SIGN_IN = 'Verify sign in',
+  WALLET_INTERACTION = 'Wallet interaction'
 }
 
 export enum ClickEvents {

--- a/src/modules/analytics/types.ts
+++ b/src/modules/analytics/types.ts
@@ -4,7 +4,11 @@ export enum TrackingEvents {
   LOGIN_ERROR = 'Login Error',
   CLICK = 'Click Button',
   AVATAR_EDIT_SUCCESS = 'Avatar Edit Success',
-  TERMS_OF_SERVICE_SUCCESS = 'Terms of service success'
+  TERMS_OF_SERVICE_SUCCESS = 'Terms of service success',
+  REQUEST_EXPIRED = 'Expired request',
+  REQUEST_LOADING_ERROR = 'Error loading request',
+  WALLET_INTERACTION_REQUEST_TYPE = 'Wallet interaction request type',
+  VERIFY_SIGN_IN_REQUEST_TYPE = 'Verify sign in request type'
 }
 
 export enum ClickEvents {


### PR DESCRIPTION
This PR adds more analytics to the auth site request page.
These analytics are intended to:
- Log expired requests.
- Log the type of the request, if it's a sign in request or a wallet interaction one.
- Request loading errors