### PR TITLE
fix: Wrong message being displayed initially while singing in with Magic

### DIFF
--- a/src/components/Pages/CallbackPage/CallbackPage.tsx
+++ b/src/components/Pages/CallbackPage/CallbackPage.tsx
@@ -24,7 +24,7 @@ export const CallbackPage = () => {
   const { url: redirectTo, redirect } = useAfterLoginRedirection()
   const navigate = useNavigateWithSearchParams()
   const [logInStarted, setLogInStarted] = useState(false)
-  const [state, setConnectionModalState] = useState(ConnectionModalState.WAITING_FOR_CONFIRMATION)
+  const [state, setConnectionModalState] = useState(ConnectionModalState.VALIDATING_SIGN_IN)
   const { flags, initialized } = useContext(FeatureFlagsContext)
   const [targetConfig] = useTargetConfig()
 
@@ -83,7 +83,9 @@ export const CallbackPage = () => {
     })
 
     try {
-      setConnectionModalState(ConnectionModalState.VALIDATING_SIGN_IN)
+      if (!flags[FeatureFlagsKeys.DAPPS_MAGIC_AUTO_SIGN]) {
+        setConnectionModalState(ConnectionModalState.VALIDATING_SIGN_IN)
+      }
       await magic?.oauth2.getRedirectResult()
       // If the flag is enabled, proceed with the simplified avatar setup flow.
       if (flags[FeatureFlagsKeys.DAPPS_MAGIC_AUTO_SIGN]) {


### PR DESCRIPTION
This PR sets as the starting state, the `VALIDATING_SING_IN` state which prevents the `WAITING_FOR_CONFIRMATION` state from being shown.