### PR TITLE
feat: Tag exceptions to see if users are using web2 wallets

### DIFF
--- a/src/components/Pages/LoginPage/LoginPage.tsx
+++ b/src/components/Pages/LoginPage/LoginPage.tsx
@@ -100,20 +100,13 @@ export const LoginPage = () => {
         method: connectionType,
         type: providerType
       })
-      if (isLoggingInThroughSocial) {
-        try {
+      try {
+        if (isLoggingInThroughSocial) {
           setConnectionModalState(ConnectionModalState.LOADING_MAGIC)
           // Wait 800 ms for the tracking to be completed
           await wait(800)
           await connectToSocialProvider(connectionType, flags[FeatureFlagsKeys.MAGIC_TEST], redirectTo)
-        } catch (error) {
-          console.error('Error', isErrorWithMessage(error) ? error.message : JSON.stringify(error))
-          captureException(error, { tags: { isWeb2Wallet: true, connectionType } })
-          getAnalytics()?.track(TrackingEvents.LOGIN_ERROR, { error: isErrorWithMessage(error) ? error.message : error })
-          setConnectionModalState(ConnectionModalState.ERROR)
-        }
-      } else {
-        try {
+        } else {
           setShowConnectionModal(true)
           setConnectionModalState(ConnectionModalState.CONNECTING_WALLET)
           const connectionData = await connectToProvider(connectionType)
@@ -153,15 +146,15 @@ export const LoginPage = () => {
 
           redirect()
           setShowConnectionModal(false)
-        } catch (error) {
-          console.error('Error', isErrorWithMessage(error) ? error.message : JSON.stringify(error))
-          captureException(error, { tags: { isWeb2Wallet: true, connectionType } })
-          getAnalytics()?.track(TrackingEvents.LOGIN_ERROR, { error: isErrorWithMessage(error) ? error.message : error })
-          if (isErrorWithName(error) && error.name === 'ErrorUnlockingWallet') {
-            setConnectionModalState(ConnectionModalState.ERROR_LOCKED_WALLET)
-          } else {
-            setConnectionModalState(ConnectionModalState.ERROR)
-          }
+        }
+      } catch (error) {
+        console.error('Error', isErrorWithMessage(error) ? error.message : JSON.stringify(error))
+        captureException(error, { tags: { isWeb2Wallet: isLoggingInThroughSocial, connectionType } })
+        getAnalytics()?.track(TrackingEvents.LOGIN_ERROR, { error: isErrorWithMessage(error) ? error.message : error })
+        if (isErrorWithName(error) && error.name === 'ErrorUnlockingWallet') {
+          setConnectionModalState(ConnectionModalState.ERROR_LOCKED_WALLET)
+        } else {
+          setConnectionModalState(ConnectionModalState.ERROR)
         }
       }
     },


### PR DESCRIPTION
This PR adds tags to some `captureException` calls so we can know if the user is using web2 wallets. It also captures the social log in process that was not being captured before.