### PR TITLE
fix: Set the connection modal to the validating sign in state

### DIFF
--- a/src/components/Pages/CallbackPage/CallbackPage.tsx
+++ b/src/components/Pages/CallbackPage/CallbackPage.tsx
@@ -95,7 +95,7 @@ export const CallbackPage = () => {
   return (
     <ConnectionModal
       open={true}
-      state={ConnectionModalState.WAITING_FOR_SIGNATURE}
+      state={ConnectionModalState.VALIDATING_SIGN_IN}
       onTryAgain={connectAndGenerateSignature}
       providerType={flags[FeatureFlagsKeys.MAGIC_TEST] ? ProviderType.MAGIC_TEST : ProviderType.MAGIC}
     />


### PR DESCRIPTION
This PR sets the correct state for the `ConnectionModal` to "validating sign in".