### PR TITLE
feat: Use HTTP based auth server communication

### DIFF
--- a/src/components/FeatureFlagsProvider/FeatureFlagsProvider.types.ts
+++ b/src/components/FeatureFlagsProvider/FeatureFlagsProvider.types.ts
@@ -3,7 +3,8 @@ import { createContext } from 'react'
 export enum FeatureFlagsKeys {
   MAGIC_TEST = 'dapps-magic-dev-test',
   DAPPS_MAGIC_AUTO_SIGN = 'dapps-magic-auto-sign',
-  LOGIN_ON_SETUP = 'dapps-login-on-setup'
+  LOGIN_ON_SETUP = 'dapps-login-on-setup',
+  HTTP_AUTH = 'dapps-http-auth'
 }
 
 export type FeatureFlagsContextType = {

--- a/src/components/Pages/RequestPage/Views/TimeoutError.tsx
+++ b/src/components/Pages/RequestPage/Views/TimeoutError.tsx
@@ -8,9 +8,9 @@ export const TimeoutError = ({ requestId }: { requestId: string }) => {
   return (
     <Container requestId={requestId}>
       <div className={styles.errorLogo}></div>
-      <div className={styles.title}>
-        Looks like you took too long and the request has expired. If the expiration time is still running in the Explorer app, check your
-        computer's time to see if it's set correctly
+      <div className={styles.title}>Looks like you took too long and the request has expired.</div>
+      <div className={styles.subtitle}>
+        If the expiration time is still running in the Explorer app, check your computer's time to see if it's set correctly
       </div>
       <div className={styles.description}>Please return to Decentraland's {targetConfig.explorerText} to try again.</div>
       <CloseWindow />

--- a/src/components/Pages/RequestPage/Views/Views.module.css
+++ b/src/components/Pages/RequestPage/Views/Views.module.css
@@ -20,6 +20,13 @@
   margin-top: 32px;
 }
 
+.subtitle {
+  font-size: 24px;
+  font-weight: 400;
+  line-height: 29.05px;
+  margin-top: 16px;
+}
+
 .description {
   font-size: 24px;
   font-weight: 400;

--- a/src/components/Pages/SetupPage/SetupPage.tsx
+++ b/src/components/Pages/SetupPage/SetupPage.tsx
@@ -19,7 +19,7 @@ import { useAfterLoginRedirection } from '../../../hooks/redirection'
 import { getAnalytics } from '../../../modules/analytics/segment'
 import { ClickEvents, TrackingEvents } from '../../../modules/analytics/types'
 import { fetchProfile } from '../../../modules/profile'
-import { createAuthServerClient, ExpiredRequestError, RecoverResponse } from '../../../shared/auth'
+import { createAuthServerHttpClient, createAuthServerWsClient, ExpiredRequestError, RecoverResponse } from '../../../shared/auth'
 import { useCurrentConnectionData } from '../../../shared/connection/hooks'
 import { isErrorWithMessage } from '../../../shared/errors'
 import { locations } from '../../../shared/locations'
@@ -82,7 +82,7 @@ export const SetupPage = () => {
   const isMobile = useMobileMediaQuery()
   const { url: redirectTo, redirect } = useAfterLoginRedirection()
   const { isLoading: isConnecting, account, identity, provider, providerType } = useCurrentConnectionData()
-  const authServerClient = useRef(createAuthServerClient())
+  const authServerClient = useRef(createAuthServerWsClient())
   const navigate = useNavigateWithSearchParams()
 
   const requestId = useMemo(() => {
@@ -361,6 +361,12 @@ export const SetupPage = () => {
       if (profile) {
         console.warn('Profile already exists')
         return redirect()
+      }
+
+      if (flags[FeatureFlagsKeys.HTTP_AUTH]) {
+        authServerClient.current = createAuthServerHttpClient()
+      } else {
+        authServerClient.current = createAuthServerWsClient()
       }
 
       setInitialized(true)

--- a/src/shared/auth/httpClient.ts
+++ b/src/shared/auth/httpClient.ts
@@ -1,0 +1,129 @@
+import { captureException } from '@sentry/react'
+import { getAnalytics } from '../../modules/analytics/segment'
+import { RequestInteractionType, TrackingEvents } from '../../modules/analytics/types'
+import { config } from '../../modules/config'
+import { isErrorWithMessage } from '../errors'
+import { DifferentSenderError, ExpiredRequestError, RequestNotFoundError } from './errors'
+import { OutcomeError, RecoverResponse } from './types'
+export const createAuthServerHttpClient = (authServerUrl?: string) => {
+  const baseUrl = authServerUrl ?? config.get('AUTH_SERVER_URL')
+
+  const extractError = async (response: Response, requestId: string) => {
+    let data: { error?: string }
+    try {
+      data = await response.json()
+    } catch (error) {
+      throw new Error('Unknown error')
+    }
+
+    if (data.error?.includes('not found')) {
+      throw new RequestNotFoundError(requestId)
+    } else if (data.error?.includes('has expired')) {
+      throw new ExpiredRequestError(requestId)
+    } else if (data.error) {
+      throw new Error(data.error)
+    }
+
+    throw new Error('Unknown error')
+  }
+
+  const sendSuccessfulOutcome = async (requestId: string, sender: string, result: any): Promise<void> => {
+    try {
+      const response = await fetch(baseUrl + '/v2/outcomes/' + requestId, {
+        method: 'POST',
+        body: JSON.stringify({
+          sender,
+          result
+        })
+      })
+
+      if (!response.ok) {
+        await extractError(response, requestId)
+      }
+    } catch (e) {
+      console.error('Error sending outcome', e)
+      captureException(e)
+      throw e
+    }
+  }
+
+  const sendFailedOutcome = async (requestId: string, sender: string, error: OutcomeError): Promise<void> => {
+    try {
+      const response = await fetch(baseUrl + '/v2/outcomes/' + requestId, {
+        method: 'POST',
+        body: JSON.stringify({
+          sender,
+          error
+        })
+      })
+
+      if (!response.ok) {
+        await extractError(response, requestId)
+      }
+    } catch (e) {
+      console.error('Error sending outcome', e)
+      captureException(e)
+      throw e
+    }
+  }
+
+  const recover = async (requestId: string, signerAddress: string): Promise<RecoverResponse> => {
+    let recoverResponse: RecoverResponse | undefined
+
+    try {
+      const response = await fetch(baseUrl + '/v2/requests/' + requestId, {
+        method: 'GET'
+      })
+
+      if (!response.ok) {
+        await extractError(response, requestId)
+      }
+
+      const recoverResponse = await response.json()
+
+      // If the sender defined in the request is different than the one that is connected, show an error.
+      if (recoverResponse.sender && recoverResponse.sender !== signerAddress.toLowerCase()) {
+        throw new DifferentSenderError(signerAddress, recoverResponse.sender)
+      }
+
+      if (recoverResponse.expiration && new Date(recoverResponse.expiration) < new Date()) {
+        throw new ExpiredRequestError(requestId, recoverResponse.expiration)
+      }
+
+      switch (recoverResponse.method) {
+        case 'dcl_personal_sign':
+          getAnalytics()?.track(TrackingEvents.REQUEST_INTERACTION, {
+            type: RequestInteractionType.VERIFY_SIGN_IN,
+            browserTime: Date.now(),
+            requestTime: new Date(recoverResponse.expiration).getTime(),
+            requestType: recoverResponse?.method
+          })
+          break
+        case 'eth_sendTransaction':
+          getAnalytics()?.track(TrackingEvents.REQUEST_INTERACTION, {
+            type: RequestInteractionType.WALLET_INTERACTION,
+            requestType: recoverResponse.method
+          })
+          break
+        default:
+          getAnalytics()?.track(TrackingEvents.REQUEST_INTERACTION, {
+            type: RequestInteractionType.WALLET_INTERACTION,
+            requestType: recoverResponse.method
+          })
+      }
+
+      return recoverResponse
+    } catch (e) {
+      console.error('Error recovering request', e)
+      captureException(e)
+      getAnalytics()?.track(TrackingEvents.REQUEST_LOADING_ERROR, {
+        browserTime: Date.now(),
+        requestType: recoverResponse?.method ?? 'Unknown',
+        error: isErrorWithMessage(e) ? e.message : 'Unknown error'
+      })
+      throw e
+    }
+  }
+
+  return { recover, sendSuccessfulOutcome, sendFailedOutcome }
+}

--- a/src/shared/auth/index.ts
+++ b/src/shared/auth/index.ts
@@ -1,2 +1,4 @@
-export * from './client'
 export * from './errors'
+export * from './httpClient'
+export * from './types'
+export * from './wsClient'

--- a/src/shared/auth/types.ts
+++ b/src/shared/auth/types.ts
@@ -1,0 +1,14 @@
+export type RecoverResponse = {
+  sender: string
+  expiration: string
+  method: string
+  code?: string
+  error?: string
+  params?: any[]
+}
+
+export type OutcomeResponse = {
+  error?: string
+}
+
+export type OutcomeError = { code: number; message: string }

--- a/src/shared/auth/weClient.spec.ts
+++ b/src/shared/auth/weClient.spec.ts
@@ -1,0 +1,296 @@
+import { io } from 'socket.io-client'
+import { getAnalytics } from '../../modules/analytics/segment'
+import { config } from '../../modules/config'
+import { DifferentSenderError, ExpiredRequestError, RequestNotFoundError } from './errors'
+import { RecoverResponse } from './types'
+import { createAuthServerWsClient } from './wsClient'
+
+// Mock dependencies
+jest.mock('socket.io-client')
+jest.mock('@sentry/react')
+jest.mock('../../modules/analytics/segment')
+jest.mock('../../modules/config')
+
+// Mock console.error to prevent errors from being logged
+jest.spyOn(console, 'error').mockImplementation(() => undefined)
+
+describe('createAuthServerClient', () => {
+  // Common test variables
+  const mockUrl = 'http://mock-auth-server.com'
+  const mockRequestId = 'mock-request-id'
+  const mockSender = '0xmocksender'
+  const mockSignerAddress = '0xMockSignerAddress'
+  const mockSignerAddressLower = '0xmocksigneraddress'
+
+  // Mock socket and its methods
+  const mockEmitWithAck = jest.fn()
+  const mockClose = jest.fn()
+  const mockOn = jest.fn()
+  const mockSocket = {
+    on: mockOn,
+    emitWithAck: mockEmitWithAck,
+    close: mockClose
+  }
+
+  // Mock analytics
+  const mockTrack = jest.fn()
+  const mockAnalytics = { track: mockTrack }
+
+  beforeEach(() => {
+    // Reset all mocks
+    jest.clearAllMocks()
+
+    // Setup socket.io mock
+    ;(io as jest.Mock).mockReturnValue(mockSocket)
+
+    // Setup config mock
+    ;(config.get as jest.Mock).mockReturnValue(mockUrl)
+
+    // Setup analytics mock
+    ;(getAnalytics as jest.Mock).mockReturnValue(mockAnalytics)
+
+    // Setup socket connect event handler
+    mockOn.mockImplementation((event, callback) => {
+      if (event === 'connect') {
+        callback()
+      }
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('when recovering a request', () => {
+    let client: ReturnType<typeof createAuthServerWsClient>
+    let mockResponse: RecoverResponse
+
+    beforeEach(() => {
+      client = createAuthServerWsClient()
+
+      mockResponse = {
+        sender: mockSignerAddressLower,
+        expiration: new Date(Date.now() + 3600000).toISOString(), // 1 hour in the future
+        method: 'dcl_personal_sign'
+      }
+
+      mockEmitWithAck.mockResolvedValueOnce(mockResponse)
+    })
+
+    describe('when the request is successful', () => {
+      beforeEach(() => {
+        // No additional setup needed
+      })
+
+      it('should connect to the server and emit the recover event', async () => {
+        await client.recover(mockRequestId, mockSignerAddress)
+
+        expect(io).toHaveBeenCalledWith(mockUrl)
+        expect(mockOn).toHaveBeenCalledWith('connect', expect.any(Function))
+        expect(mockEmitWithAck).toHaveBeenCalledWith('recover', { requestId: mockRequestId })
+        expect(mockClose).toHaveBeenCalled()
+      })
+
+      it('should return the response if everything is valid', async () => {
+        const result = await client.recover(mockRequestId, mockSignerAddress)
+
+        expect(result).toEqual(mockResponse)
+      })
+    })
+
+    describe('when the response contains an error', () => {
+      const errorMessage = 'Error recovering request'
+
+      beforeEach(() => {
+        mockResponse.error = errorMessage
+      })
+
+      it('should throw an error with the error message', async () => {
+        await expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toThrow(errorMessage)
+      })
+    })
+
+    describe('when the sender does not match', () => {
+      beforeEach(() => {
+        mockResponse.sender = 'different-sender'
+      })
+
+      it('should throw a DifferentSenderError', async () => {
+        await expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toBeInstanceOf(DifferentSenderError)
+      })
+    })
+
+    describe('when the request is expired', () => {
+      beforeEach(() => {
+        mockResponse.expiration = new Date(Date.now() - 3600000).toISOString() // 1 hour in the past
+      })
+
+      it('should throw an ExpiredRequestError', async () => {
+        await expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toBeInstanceOf(ExpiredRequestError)
+      })
+    })
+
+    describe('when the request fails due to network error', () => {
+      beforeEach(() => {
+        mockEmitWithAck.mockReset()
+        mockEmitWithAck.mockRejectedValueOnce(new Error('Network error'))
+      })
+
+      it('should throw the network error', async () => {
+        await expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toThrow('Network error')
+      })
+    })
+  })
+
+  describe('when sending a successful outcome', () => {
+    let client: ReturnType<typeof createAuthServerWsClient>
+    const mockResult = { success: true }
+
+    beforeEach(() => {
+      client = createAuthServerWsClient()
+    })
+
+    describe('when the request is successful', () => {
+      beforeEach(() => {
+        mockEmitWithAck.mockResolvedValueOnce({})
+      })
+
+      it('should emit the outcome event with success result', async () => {
+        await client.sendSuccessfulOutcome(mockRequestId, mockSender, mockResult)
+
+        expect(mockEmitWithAck).toHaveBeenCalledWith('outcome', {
+          requestId: mockRequestId,
+          sender: mockSender,
+          result: mockResult
+        })
+        expect(mockClose).toHaveBeenCalled()
+      })
+    })
+
+    describe('when the response contains an error', () => {
+      let message: { error: string }
+      beforeEach(() => {
+        message = { error: 'an error' }
+        mockEmitWithAck.mockResolvedValueOnce(message)
+      })
+
+      describe('when the error is an expiration error', () => {
+        beforeEach(() => {
+          message.error = 'Request has expired'
+        })
+
+        it('should propagate the expiration error', async () => {
+          await expect(client.sendSuccessfulOutcome(mockRequestId, mockSender, {})).rejects.toBeInstanceOf(ExpiredRequestError)
+        })
+      })
+
+      describe('when the error is a not found error', () => {
+        beforeEach(() => {
+          message.error = 'Request not found'
+        })
+
+        it('should propagate the not found error', async () => {
+          await expect(client.sendSuccessfulOutcome(mockRequestId, mockSender, {})).rejects.toBeInstanceOf(RequestNotFoundError)
+        })
+      })
+
+      describe('when the error is a different error', () => {
+        beforeEach(() => {
+          message.error = 'Unknown error'
+        })
+
+        it('should propagate the error', async () => {
+          await expect(client.sendSuccessfulOutcome(mockRequestId, mockSender, {})).rejects.toThrow(message.error)
+        })
+      })
+    })
+
+    describe('when the request fails due to network error', () => {
+      const error = new Error('Network error')
+
+      beforeEach(() => {
+        mockEmitWithAck.mockRejectedValueOnce(error)
+      })
+
+      it('should handle and rethrow the error', async () => {
+        await expect(client.sendSuccessfulOutcome(mockRequestId, mockSender, {})).rejects.toThrow('Network error')
+      })
+    })
+  })
+
+  describe('when sending a failed outcome', () => {
+    let client: ReturnType<typeof createAuthServerWsClient>
+    const mockError = { code: 400, message: 'Bad request' }
+
+    beforeEach(() => {
+      client = createAuthServerWsClient()
+    })
+
+    describe('when the request is successful', () => {
+      beforeEach(() => {
+        mockEmitWithAck.mockResolvedValueOnce({})
+      })
+
+      it('should emit the outcome event with error details', async () => {
+        await client.sendFailedOutcome(mockRequestId, mockSender, mockError)
+
+        expect(mockEmitWithAck).toHaveBeenCalledWith('outcome', {
+          requestId: mockRequestId,
+          sender: mockSender,
+          error: mockError
+        })
+        expect(mockClose).toHaveBeenCalled()
+      })
+    })
+
+    describe('when the response contains an error', () => {
+      let message: { error: string }
+      beforeEach(() => {
+        message = { error: 'an error' }
+        mockEmitWithAck.mockResolvedValueOnce(message)
+      })
+
+      describe('when the error is an expiration error', () => {
+        beforeEach(() => {
+          message.error = 'Request has expired'
+        })
+
+        it('should propagate the expiration error', async () => {
+          await expect(client.sendSuccessfulOutcome(mockRequestId, mockSender, {})).rejects.toBeInstanceOf(ExpiredRequestError)
+        })
+      })
+
+      describe('when the error is a not found error', () => {
+        beforeEach(() => {
+          message.error = 'Request not found'
+        })
+
+        it('should propagate the not found error', async () => {
+          await expect(client.sendSuccessfulOutcome(mockRequestId, mockSender, {})).rejects.toBeInstanceOf(RequestNotFoundError)
+        })
+      })
+
+      describe('when the error is a different error', () => {
+        beforeEach(() => {
+          message.error = 'Unknown error'
+        })
+
+        it('should propagate the error', async () => {
+          await expect(client.sendSuccessfulOutcome(mockRequestId, mockSender, {})).rejects.toThrow(message.error)
+        })
+      })
+    })
+
+    describe('when the request fails due to network error', () => {
+      const error = new Error('Network error')
+
+      beforeEach(() => {
+        mockEmitWithAck.mockRejectedValueOnce(error)
+      })
+
+      it('should handle and rethrow the error', async () => {
+        await expect(client.sendFailedOutcome(mockRequestId, mockSender, mockError)).rejects.toThrow('Network error')
+      })
+    })
+  })
+})

--- a/src/shared/auth/wsClient.ts
+++ b/src/shared/auth/wsClient.ts
@@ -5,23 +5,9 @@ import { RequestInteractionType, TrackingEvents } from '../../modules/analytics/
 import { config } from '../../modules/config'
 import { isErrorWithMessage } from '../errors'
 import { DifferentSenderError, ExpiredRequestError, RequestNotFoundError } from './errors'
+import { OutcomeError, OutcomeResponse, RecoverResponse } from './types'
 
-export type RecoverResponse = {
-  sender: string
-  expiration: string
-  method: string
-  code?: string
-  error?: string
-  params?: any[]
-}
-
-export type OutcomeResponse = {
-  error?: string
-}
-
-type OutcomeError = { code: number; message: string }
-
-export const createAuthServerClient = (authServerUrl?: string) => {
+export const createAuthServerWsClient = (authServerUrl?: string) => {
   const url = authServerUrl ?? config.get('AUTH_SERVER_URL')
 
   const request = async <T>(
@@ -78,7 +64,7 @@ export const createAuthServerClient = (authServerUrl?: string) => {
     }
   }
 
-  const recover = async (requestId: string, signerAddress: string) => {
+  const recover = async (requestId: string, signerAddress: string): Promise<RecoverResponse> => {
     let response: RecoverResponse | undefined
 
     try {


### PR DESCRIPTION
This PR adds the capability of communicating to the auth-server via HTTP using a FF.
The idea of this PR is to improve reliability when authenticating to the E@.