### PR TITLE
fix: HTTP Client errors

### DIFF
--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -177,7 +177,7 @@ export const RequestPage = () => {
     return () => {
       clearTimeout(timeoutRef.current)
     }
-  }, [toLoginPage, toSetupPage, account, provider, providerType, isConnecting])
+  }, [toLoginPage, toSetupPage, account, provider, providerType, isConnecting, initializedFlags])
 
   useEffect(() => {
     // The timeout is only necessary on the verify sign in and wallet interaction views.

--- a/src/components/Pages/RequestPage/Views/RecoverError.tsx
+++ b/src/components/Pages/RequestPage/Views/RecoverError.tsx
@@ -8,7 +8,7 @@ export const RecoverError = ({ error }: { error: React.ReactNode }) => (
     <div className={styles.title}>There was an error recovering the request...</div>
     <div className={styles.description}>
       The request is not available anymore. Feel free to create a new one and try again. If the expiration time is still running in the
-      Explorer app, check your computer's time to see if it's set correctly
+      Explorer app, check your computer's time to see if it's set correctly.
     </div>
     <CloseWindow />
     <div className={styles.errorMessage}>{error}</div>

--- a/src/components/Pages/RequestPage/Views/TimeoutError.tsx
+++ b/src/components/Pages/RequestPage/Views/TimeoutError.tsx
@@ -10,7 +10,7 @@ export const TimeoutError = ({ requestId }: { requestId: string }) => {
       <div className={styles.errorLogo}></div>
       <div className={styles.title}>Looks like you took too long and the request has expired.</div>
       <div className={styles.subtitle}>
-        If the expiration time is still running in the Explorer app, check your computer's time to see if it's set correctly
+        If the expiration time is still running in the Explorer app, check your computer's time to see if it's set correctly.
       </div>
       <div className={styles.description}>Please return to Decentraland's {targetConfig.explorerText} to try again.</div>
       <CloseWindow />

--- a/src/shared/auth/httpClient.spec.ts
+++ b/src/shared/auth/httpClient.spec.ts
@@ -157,6 +157,10 @@ describe('createAuthServerClient', () => {
 
         expect(mockFetch).toHaveBeenCalledWith(mockUrl + '/v2/outcomes/' + mockRequestId, {
           method: 'POST',
+          headers: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            'Content-Type': 'application/json'
+          },
           body: JSON.stringify({
             sender: mockSender,
             result: mockResult
@@ -240,6 +244,10 @@ describe('createAuthServerClient', () => {
 
         expect(mockFetch).toHaveBeenCalledWith(mockUrl + '/v2/outcomes/' + mockRequestId, {
           method: 'POST',
+          headers: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            'Content-Type': 'application/json'
+          },
           body: JSON.stringify({
             sender: mockSender,
             error: mockError

--- a/src/shared/auth/httpClient.ts
+++ b/src/shared/auth/httpClient.ts
@@ -31,6 +31,10 @@ export const createAuthServerHttpClient = (authServerUrl?: string) => {
     try {
       const response = await fetch(baseUrl + '/v2/outcomes/' + requestId, {
         method: 'POST',
+        headers: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          'Content-Type': 'application/json'
+        },
         body: JSON.stringify({
           sender,
           result
@@ -51,6 +55,10 @@ export const createAuthServerHttpClient = (authServerUrl?: string) => {
     try {
       const response = await fetch(baseUrl + '/v2/outcomes/' + requestId, {
         method: 'POST',
+        headers: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          'Content-Type': 'application/json'
+        },
         body: JSON.stringify({
           sender,
           error


### PR DESCRIPTION
This PR fixes:
- The HTTP client not sending the correct content-type.
- The `RequestPage` not having the `initializedFlags` dependency in the `useEffect`
- Some text in the pages.