### PR TITLE
fix: Timeout FF request

### DIFF
--- a/src/components/FeatureFlagsProvider/FeatureFlagsProvider.tsx
+++ b/src/components/FeatureFlagsProvider/FeatureFlagsProvider.tsx
@@ -1,8 +1,7 @@
 import { PropsWithChildren, useEffect, useRef, useState } from 'react'
 import { config } from '../../modules/config'
+import { THIRTY_SECONDS } from '../../shared/time'
 import { defaultFeatureFlagsContextValue, FeatureFlagsContext } from './FeatureFlagsProvider.types'
-
-const THIRTY_SECONDS = 30 * 1000
 
 export const FeatureFlagsProvider = (props: PropsWithChildren<unknown>) => {
   const [value, setValue] = useState(defaultFeatureFlagsContextValue)

--- a/src/shared/time.ts
+++ b/src/shared/time.ts
@@ -1,1 +1,2 @@
+export const THIRTY_SECONDS = 30 * 1000
 export const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))


### PR DESCRIPTION
This PR changes the FeatureFlags provider to timeout if it takes more than 30 second to prevent pages that require the flags to wait up to 3 minutes for it to fail.