### PR TITLE
fix: Re-create user when profile is incomplete

### DIFF
--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -22,6 +22,7 @@ import {
 import { useCurrentConnectionData } from '../../../shared/connection'
 import { isErrorWithMessage, isRpcError } from '../../../shared/errors'
 import { locations } from '../../../shared/locations'
+import { isProfileComplete } from '../../../shared/profile'
 import { FeatureFlagsContext, FeatureFlagsKeys } from '../../FeatureFlagsProvider/FeatureFlagsProvider.types'
 import { Container } from './Container'
 import { DeniedSignIn } from './Views/DeniedSignIn'
@@ -107,7 +108,7 @@ export const RequestPage = () => {
       const profile = await fetchProfile(account)
 
       // `alternative` has its own set up
-      if (!targetConfig.skipSetup && !profile) {
+      if ((!targetConfig.skipSetup && !profile) || (profile && !isProfileComplete(profile))) {
         // Goes to the setup page if the connected account does not have a profile yet.
         console.log("There's no profile but the user is logged in, going to setup page")
         toSetupPage()

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -110,7 +110,7 @@ export const RequestPage = () => {
       // `alternative` has its own set up
       if ((!targetConfig.skipSetup && !profile) || (profile && !isProfileComplete(profile))) {
         // Goes to the setup page if the connected account does not have a profile yet.
-        console.log("There's no profile but the user is logged in, going to setup page")
+        console.log("There's no profile or the profile is not complete but the user is logged in, going to setup page")
         toSetupPage()
         return
       }

--- a/src/components/Pages/SetupPage/SetupPage.tsx
+++ b/src/components/Pages/SetupPage/SetupPage.tsx
@@ -23,6 +23,7 @@ import { createAuthServerHttpClient, createAuthServerWsClient, ExpiredRequestErr
 import { useCurrentConnectionData } from '../../../shared/connection/hooks'
 import { isErrorWithMessage } from '../../../shared/errors'
 import { locations } from '../../../shared/locations'
+import { isProfileComplete } from '../../../shared/profile'
 import { ConnectionModal, ConnectionModalState } from '../../ConnectionModal'
 import { CustomWearablePreview } from '../../CustomWearablePreview'
 import { FeatureFlagsContext, FeatureFlagsKeys } from '../../FeatureFlagsProvider'
@@ -358,7 +359,7 @@ export const SetupPage = () => {
       const profile = await fetchProfile(account)
 
       // Check that the connected account does not have a profile already.
-      if (profile) {
+      if (profile && isProfileComplete(profile)) {
         console.warn('Profile already exists')
         return redirect()
       }

--- a/src/shared/profile.ts
+++ b/src/shared/profile.ts
@@ -1,0 +1,5 @@
+import { Profile } from 'dcl-catalyst-client/dist/client/specs/catalyst.schemas'
+
+export function isProfileComplete(profile: Profile) {
+  return profile.avatars?.[0]?.name !== undefined
+}


### PR DESCRIPTION
Make the user complete the profile setup if their profile is old (they don't have name).