### PR TITLE
fix: Changing account request id propagation

### DIFF
--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -294,7 +294,7 @@ export const RequestPage = () => {
     case View.TIMEOUT:
       return <TimeoutError requestId={requestId} />
     case View.DIFFERENT_ACCOUNT:
-      return <DifferentAccountError />
+      return <DifferentAccountError requestId={requestId} />
     case View.LOADING_ERROR:
       return <RecoverError error={error} />
     case View.VERIFY_SIGN_IN_ERROR:
@@ -303,7 +303,7 @@ export const RequestPage = () => {
     case View.VERIFY_SIGN_IN_COMPLETE:
       return <SignInComplete />
     case View.VERIFY_SIGN_IN_DENIED:
-      return <DeniedSignIn />
+      return <DeniedSignIn requestId={requestId} />
     case View.WALLET_INTERACTION_COMPLETE:
       return <WalletInteractionComplete />
     case View.WALLET_INTERACTION_DENIED:
@@ -316,7 +316,7 @@ export const RequestPage = () => {
       )
     case View.VERIFY_SIGN_IN:
       return (
-        <Container canChangeAccount>
+        <Container canChangeAccount requestId={requestId}>
           <div className={viewStyles.logo}></div>
           <div className={viewStyles.title}>Verify Sign In</div>
           <div className={viewStyles.description}>Does the verification number below match the one in the {targetConfig.explorerText}?</div>
@@ -335,7 +335,7 @@ export const RequestPage = () => {
       )
     case View.WALLET_INTERACTION:
       return (
-        <Container canChangeAccount>
+        <Container canChangeAccount requestId={requestId}>
           <Web2TransactionModal
             isOpen={isTransactionModalOpen}
             transactionCostAmount={formatEther((transactionGasCost ?? 0).toString())}

--- a/src/components/Pages/RequestPage/Views/DeniedSignIn.tsx
+++ b/src/components/Pages/RequestPage/Views/DeniedSignIn.tsx
@@ -2,9 +2,9 @@ import { Container } from '../Container'
 import { CloseWindow } from './CloseWindow'
 import styles from './Views.module.css'
 
-export const DeniedSignIn = () => {
+export const DeniedSignIn = ({ requestId }: { requestId: string }) => {
   return (
-    <Container canChangeAccount>
+    <Container canChangeAccount requestId={requestId}>
       <div className={styles.errorLogo}></div>
       <div className={styles.title}>Did the number not match, or was this action not taken by you?</div>
       <div className={styles.description}>

--- a/src/components/Pages/RequestPage/Views/DifferentAccountError.tsx
+++ b/src/components/Pages/RequestPage/Views/DifferentAccountError.tsx
@@ -2,10 +2,10 @@ import { useTargetConfig } from '../../../../hooks/targetConfig'
 import { Container } from '../Container'
 import styles from './Views.module.css'
 
-export const DifferentAccountError = () => {
+export const DifferentAccountError = ({ requestId }: { requestId: string }) => {
   const [targetConfig] = useTargetConfig()
   return (
-    <Container canChangeAccount>
+    <Container canChangeAccount requestId={requestId}>
       <div className={styles.errorLogo}></div>
       <div className={styles.title}>Looks like you are connected with a different account.</div>
       <div className={styles.description}>Please change your wallet account to the one connected to the {targetConfig.explorerText}.</div>

--- a/src/components/Pages/SetupPage/SetupPage.tsx
+++ b/src/components/Pages/SetupPage/SetupPage.tsx
@@ -406,7 +406,7 @@ export const SetupPage = () => {
 
   switch (view) {
     case View.DIFFERENT_ACCOUNT:
-      return <DifferentAccountError />
+      return <DifferentAccountError requestId={requestId ?? ''} />
     case View.RECOVER_ERROR:
       return <RecoverError error={requestError} />
     case View.SIGN_IN_COMPLETE:


### PR DESCRIPTION
In the latest refactor, the different components that were created where missing the `requestId` when instantiating them, causing the "Return to login" anchor used to change accounts to not propagate the request id.