### PR TITLE
feat: fetch referral server for newly referred users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "classnames": "^2.3.2",
         "dcl-catalyst-client": "^21.5.5",
         "decentraland-connect": "^9.1.0",
+        "decentraland-crypto-fetch": "^2.0.1",
         "decentraland-ui": "^6.13.0",
         "ethers": "^6.8.0",
         "isbot": "^5.1.22",
@@ -7071,6 +7072,16 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "license": "MIT"
     },
+    "node_modules/core-js-pure": {
+      "version": "3.42.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.42.0.tgz",
+      "integrity": "sha512-007bM04u91fF4kMgwom2I5cQxAFIy8jVulgr9eozILl/SZE53QOqnW/+vviC+wQWLv+AunBG+8Q0TLoeSsSxRQ==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -7606,6 +7617,19 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/decentraland-crypto-fetch": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/decentraland-crypto-fetch/-/decentraland-crypto-fetch-2.0.1.tgz",
+      "integrity": "sha512-2IKu6Y4k/fle8bmU0b4zy7V1i1R0oCXtqlJumBXc4jwHUHKAcHDLD2YtgJFdd7JjsWQwf+t0DsKpzBCjQDKANg==",
+      "dependencies": {
+        "@dcl/crypto": "^3.3.1",
+        "core-js-pure": "^3.19.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
     },
     "node_modules/decentraland-ui": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "classnames": "^2.3.2",
     "dcl-catalyst-client": "^21.5.5",
     "decentraland-connect": "^9.1.0",
+    "decentraland-crypto-fetch": "^2.0.1",
     "decentraland-ui": "^6.13.0",
     "ethers": "^6.8.0",
     "isbot": "^5.1.22",

--- a/src/components/Pages/CallbackPage/CallbackPage.tsx
+++ b/src/components/Pages/CallbackPage/CallbackPage.tsx
@@ -48,7 +48,9 @@ export const CallbackPage = () => {
           // If the connected account does not have a profile, redirect the user to the setup page to create a new one.
           // The setup page should then redirect the user to the url provided as query param if available.
           if (!profile) {
-            return navigate(locations.setup(redirectTo))
+            const url = new URL(window.location.href)
+            const referrer = url.searchParams.get('referrer')
+            return navigate(locations.setup(redirectTo, referrer))
           }
         }
       }

--- a/src/components/Pages/LoginPage/LoginPage.tsx
+++ b/src/components/Pages/LoginPage/LoginPage.tsx
@@ -139,7 +139,9 @@ export const LoginPage = () => {
               // If the connected account does not have a profile, redirect the user to the setup page to create a new one.
               // The setup page should then redirect the user to the url provided as query param if available.
               if (!profile || (profile && !isProfileComplete(profile))) {
-                navigate(locations.setup(redirectTo))
+                const url = new URL(window.location.href)
+                const referrer = url.searchParams.get('referrer')
+                navigate(locations.setup(redirectTo, referrer))
                 return setShowConnectionModal(false)
               }
             }

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -81,7 +81,9 @@ export const RequestPage = () => {
   }, [requestId])
 
   const toSetupPage = useCallback(() => {
-    navigate(locations.setup(`/auth/requests/${requestId}?targetConfigId=${targetConfigId}`))
+    const url = new URL(window.location.href)
+    const referrer = url.searchParams.get('referrer')
+    navigate(locations.setup(`/auth/requests/${requestId}?targetConfigId=${targetConfigId}`, referrer))
   }, [requestId])
 
   useEffect(() => {

--- a/src/components/Pages/SetupPage/SetupPage.tsx
+++ b/src/components/Pages/SetupPage/SetupPage.tsx
@@ -3,12 +3,14 @@ import { useSearchParams } from 'react-router-dom'
 import { captureException } from '@sentry/react'
 import classNames from 'classnames'
 import { BrowserProvider } from 'ethers'
+import { EthAddress } from '@dcl/schemas'
 import { Button } from 'decentraland-ui/dist/components/Button/Button'
 import { Checkbox } from 'decentraland-ui/dist/components/Checkbox/Checkbox'
 import { Field } from 'decentraland-ui/dist/components/Field/Field'
 import { Loader } from 'decentraland-ui/dist/components/Loader/Loader'
 import { useMobileMediaQuery } from 'decentraland-ui/dist/components/Media/Media'
 import type { Provider } from 'decentraland-connect'
+import fetch from 'decentraland-crypto-fetch'
 import { InputOnChangeData } from 'decentraland-ui'
 import backImg from '../../../assets/images/back.svg'
 import diceImg from '../../../assets/images/dice.svg'
@@ -18,6 +20,7 @@ import { useNavigateWithSearchParams } from '../../../hooks/navigation'
 import { useAfterLoginRedirection } from '../../../hooks/redirection'
 import { getAnalytics } from '../../../modules/analytics/segment'
 import { ClickEvents, TrackingEvents } from '../../../modules/analytics/types'
+import { config } from '../../../modules/config'
 import { fetchProfile } from '../../../modules/profile'
 import { createAuthServerHttpClient, createAuthServerWsClient, ExpiredRequestError, RecoverResponse } from '../../../shared/auth'
 import { useCurrentConnectionData } from '../../../shared/connection/hooks'
@@ -394,6 +397,24 @@ export const SetupPage = () => {
       setInitialized(true)
     })()
   }, [redirect, navigate, account, identity, isConnecting, initializedFlags, flags])
+
+  useEffect(() => {
+    const url = config.get('REFERRAL_SERVER_URL')
+    const referrer = urlSearchParams.get('referrer')
+
+    if (url && identity && referrer && EthAddress.validate(referrer)) {
+      fetch(`${url}/referral-progress`, {
+        method: 'POST',
+        headers: {
+          contentType: 'application/json'
+        },
+        body: JSON.stringify({
+          referrer
+        }),
+        identity
+      })
+    }
+  }, [urlSearchParams, identity])
 
   if (!initialized) {
     return (

--- a/src/modules/config/env/dev.json
+++ b/src/modules/config/env/dev.json
@@ -7,5 +7,6 @@
   "SENTRY_DSN": "https://d0ec8d688f4d9827a270acece39153b0@o4504361728212992.ingest.us.sentry.io/4508858418266112",
   "FEATURE_FLAGS_INTERVAL": "60000",
   "BUILDER_SERVER_URL": "https://builder-api.decentraland.zone",
-  "INTERCOM_APP_ID": "z0h94kay"
+  "INTERCOM_APP_ID": "z0h94kay",
+  "REFERRAL_SERVER_URL": "https://referral-server.decentraland.zone"
 }

--- a/src/modules/config/env/prod.json
+++ b/src/modules/config/env/prod.json
@@ -7,5 +7,6 @@
   "SENTRY_DSN": "https://d0ec8d688f4d9827a270acece39153b0@o4504361728212992.ingest.us.sentry.io/4508858418266112",
   "FEATURE_FLAGS_INTERVAL": "60000",
   "BUILDER_SERVER_URL": "https://builder-api.decentraland.org",
-  "INTERCOM_APP_ID": "z0h94kay"
+  "INTERCOM_APP_ID": "z0h94kay",
+  "REFERRAL_SERVER_URL": "https://referral-server.decentraland.org"
 }

--- a/src/modules/config/env/stg.json
+++ b/src/modules/config/env/stg.json
@@ -7,5 +7,6 @@
   "SENTRY_DSN": "https://d0ec8d688f4d9827a270acece39153b0@o4504361728212992.ingest.us.sentry.io/4508858418266112",
   "FEATURE_FLAGS_INTERVAL": "60000",
   "BUILDER_SERVER_URL": "https://builder-api.decentraland.today",
-  "INTERCOM_APP_ID": "z0h94kay"
+  "INTERCOM_APP_ID": "z0h94kay",
+  "REFERRAL_SERVER_URL": "https://referral-server.decentraland.today"
 }

--- a/src/shared/locations.ts
+++ b/src/shared/locations.ts
@@ -1,7 +1,10 @@
 export const locations = {
   home: () => '/',
   login: (redirectTo?: string) => `/login${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}`,
-  setup: (redirectTo?: string) => `/setup${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}`
+  setup: (redirectTo?: string, referrer?: string | null) =>
+    `/setup${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}${
+      referrer ? `${redirectTo ? '&' : '?'}referrer=${encodeURIComponent(referrer)}` : ''
+    }`
 }
 
 export const extractRedirectToFromSearchParameters = (searchParams: URLSearchParams): string => {


### PR DESCRIPTION
This PR implements a referral system integration that allows tracking user referrals during the authentication and profile setup process. The system captures referrer information and sends it to the referral server.

## Changes
- Added `decentraland-crypto-fetch` dependency for signed fetch
- Modified the `locations.setup` function to support referrer parameter
- Updated all navigation calls to `setup` page to include referrer information
- Added referral server URL configuration for all environments (dev, staging, prod)
- Implemented referral tracking in the SetupPage component
- Added validation for referrer addresses using `EthAddress.validate`

## Technical Details
- The referral system captures the referrer's address from URL parameters
- When a user completes profile setup, a POST request is sent to the referral server
- The system validates that the referrer is a valid Ethereum address
- URL parameter handling has been improved to properly handle both `redirectTo` and `referrer` parameters