### PR TITLE
fix: login for stale profiles

### DIFF
--- a/src/hooks/useAuthFlow.ts
+++ b/src/hooks/useAuthFlow.ts
@@ -1,8 +1,10 @@
 import { useCallback, useContext } from 'react'
+import type { Profile } from 'dcl-catalyst-client/dist/client/specs/catalyst.schemas'
 import { ProviderType } from '@dcl/schemas'
 import { connection } from 'decentraland-connect'
 import { FeatureFlagsContext, FeatureFlagsKeys } from '../components/FeatureFlagsProvider'
-import { fetchProfileWithConsistencyCheck } from '../modules/profile'
+import { fetchProfileWithConsistencyCheck, redeployExistingProfile } from '../modules/profile'
+import { useCurrentConnectionData } from '../shared/connection/hook'
 import { locations } from '../shared/locations'
 import { isProfileComplete } from '../shared/profile'
 import { checkWebGpuSupport } from '../shared/utils/webgpu'
@@ -15,6 +17,7 @@ export const useAuthFlow = () => {
   const { url: redirectTo } = useAfterLoginRedirection()
   const { flags, initialized: flagInitialized } = useContext(FeatureFlagsContext)
   const [targetConfig] = useTargetConfig()
+  const { identity } = useCurrentConnectionData()
 
   const connectToMagic = useCallback(async () => {
     if (!flagInitialized) {
@@ -34,27 +37,40 @@ export const useAuthFlow = () => {
       if (targetConfig && !targetConfig.skipSetup && account) {
         // Check profile consistency across all catalysts
         const consistencyResult = await fetchProfileWithConsistencyCheck(account)
-        
-        // If profile is not consistent across catalysts, redirect to onboarding
+
+        // If profile is not consistent across catalysts, try to redeploy if we have a valid entity
         if (!consistencyResult.isConsistent) {
+          // If we have a valid entity and user identity, attempt redeployment
+          if (consistencyResult.entity && identity) {
+            try {
+              await redeployExistingProfile(consistencyResult.entity, account, identity)
+              // If redeployment succeeds, continue with the login flow
+              return redirect()
+            } catch (error) {
+              console.warn('Profile redeployment failed, falling back to onboarding:', error)
+              // Fall through to onboarding flow
+            }
+          }
+
+          // Fallback to onboarding flow (original behavior)
           const isNewOnboardingFlowEnabled = flags[FeatureFlagsKeys.NEW_ONBOARDING_FLOW]
           const hasWebGPU = await checkWebGpuSupport()
           const isAvatarSetupFlowAllowed = isNewOnboardingFlowEnabled && hasWebGPU
-          
+
           if (isAvatarSetupFlowAllowed) {
             return navigate(locations.avatarSetup(redirectTo, referrer))
           } else {
             return navigate(locations.setup(redirectTo, referrer))
           }
         }
-        
+
         // If consistent, check if profile exists and is complete
-        const profile = consistencyResult.profile
+        const profile: Profile | undefined = consistencyResult.entity?.metadata as Profile
         const isNewOnboardingFlowEnabled = flags[FeatureFlagsKeys.NEW_ONBOARDING_FLOW]
         const hasWebGPU = await checkWebGpuSupport()
         const isAvatarSetupFlowAllowed = isNewOnboardingFlowEnabled && hasWebGPU
         const isProfileIncomplete = !profile || !isProfileComplete(profile)
-        
+
         if (isProfileIncomplete && !isAvatarSetupFlowAllowed) {
           return navigate(locations.setup(redirectTo, referrer))
         } else if (isProfileIncomplete && isAvatarSetupFlowAllowed) {
@@ -64,7 +80,7 @@ export const useAuthFlow = () => {
 
       redirect()
     },
-    [targetConfig?.skipSetup, flags, navigate, redirectTo, flagInitialized]
+    [targetConfig?.skipSetup, flags, navigate, redirectTo, flagInitialized, identity]
   )
 
   return {

--- a/src/modules/profile/index.ts
+++ b/src/modules/profile/index.ts
@@ -1,12 +1,14 @@
 import { createFetchComponent } from '@well-known-components/fetch-component'
-import { createLambdasClient, createContentClient } from 'dcl-catalyst-client'
+import { createLambdasClient, createContentClient, DeploymentBuilder } from 'dcl-catalyst-client'
 import { Profile } from 'dcl-catalyst-client/dist/client/specs/catalyst.schemas'
 import { getCatalystServersFromCache } from 'dcl-catalyst-client/dist/contracts-snapshots'
+import { AuthIdentity, Authenticator } from '@dcl/crypto'
+import { Entity, EntityType } from '@dcl/schemas'
 import { config } from '../config'
 
 export interface ConsistencyResult {
   isConsistent: boolean
-  profile?: Profile
+  entity?: Entity
   error?: string
 }
 
@@ -48,33 +50,90 @@ export async function fetchProfileWithConsistencyCheck(address: string): Promise
     })
 
     if (!consistencyResult.isConsistent) {
+      // Check if we have any valid entity from inconsistent catalysts
+      // This entity can be used for redeployment to fix the inconsistency
+      const validEntity =
+        consistencyResult.upToDateEntities && consistencyResult.upToDateEntities.length > 0
+          ? consistencyResult.upToDateEntities[0]
+          : undefined
+
       return {
         isConsistent: false,
+        entity: validEntity, // Entity for potential redeployment
         error: 'Profile is not consistent across catalysts'
       }
     }
 
-    // If consistent and we have up-to-date entities, extract profile
+    // If consistent and we have up-to-date entities, return the entity
     if (consistencyResult.upToDateEntities && consistencyResult.upToDateEntities.length > 0) {
-      // Extract profile from the first up-to-date entity's metadata
       const entity = consistencyResult.upToDateEntities[0]
-      const profile = entity.metadata as Profile
       return {
         isConsistent: true,
-        profile: profile || undefined
+        entity: entity
       }
     }
 
-    // If no entities found, profile doesn't exist
+    // If no entities found, profile doesn't exist (entity will be undefined)
     return {
       isConsistent: true,
-      profile: undefined
+      entity: undefined
     }
   } catch (error) {
+    console.error('Profile consistency check failed:', error)
     // If consistency check fails, we can't determine consistency, so redirect to onboarding
     return {
       isConsistent: false,
       error: `Consistency check failed: ${error instanceof Error ? error.message : 'Unknown error'}`
     }
+  }
+}
+
+export async function redeployExistingProfile(
+  entity: Entity,
+  connectedAccount: string,
+  connectedAccountIdentity: AuthIdentity
+): Promise<void> {
+  try {
+    const PEER_URL = config.get('PEER_URL')
+    const client = createContentClient({ url: PEER_URL + '/content', fetcher: createFetchComponent() })
+
+    // Extract file hashes from entity.content
+    const contentHashesByFile = entity.content.reduce((acc, next) => ({ ...acc, [next.file]: next.hash }), {} as Record<string, string>)
+
+    // Download required assets (body.png and face256.png are typically required)
+    const bodyFile = 'body.png'
+    const face256File = 'face256.png'
+
+    const [bodyBuffer, faceBuffer] = await Promise.all([
+      client.downloadContent(contentHashesByFile[bodyFile]),
+      client.downloadContent(contentHashesByFile[face256File])
+    ])
+
+    // Prepare files map for deployment
+    const files = new Map<string, Uint8Array>()
+    files.set(bodyFile, new Uint8Array(bodyBuffer))
+    files.set(face256File, new Uint8Array(faceBuffer))
+
+    // Use existing profile metadata to preserve user customizations
+    const existingProfile = entity.metadata
+
+    // Build deployment entity with fresh timestamp
+    const deploymentEntity = await DeploymentBuilder.buildEntity({
+      type: EntityType.PROFILE,
+      pointers: [connectedAccount],
+      metadata: existingProfile, // Preserve existing profile data
+      timestamp: Date.now(), // Only update timestamp for fresh deployment
+      files
+    })
+
+    // Deploy the profile using the user's ephemeral identity
+    await client.deploy({
+      entityId: deploymentEntity.entityId,
+      files: deploymentEntity.files,
+      authChain: Authenticator.signPayload(connectedAccountIdentity, deploymentEntity.entityId)
+    })
+  } catch (error) {
+    console.error('Failed to redeploy existing profile:', error)
+    throw error
   }
 }

--- a/src/modules/profile/index.ts
+++ b/src/modules/profile/index.ts
@@ -93,47 +93,113 @@ export async function redeployExistingProfile(
   connectedAccount: string,
   connectedAccountIdentity: AuthIdentity
 ): Promise<void> {
-  try {
-    const PEER_URL = config.get('PEER_URL')
-    const client = createContentClient({ url: PEER_URL + '/content', fetcher: createFetchComponent() })
+  // Get all available catalyst servers for rotation
+  const environment = config.get('ENVIRONMENT')
+  const network = environment === 'development' ? 'sepolia' : 'mainnet'
+  const catalystServers = getCatalystServersFromCache(network)
 
-    // Extract file hashes from entity.content
-    const contentHashesByFile = entity.content.reduce((acc, next) => ({ ...acc, [next.file]: next.hash }), {} as Record<string, string>)
+  // Prepare catalyst URLs for rotation, starting with the current PEER_URL
+  const PEER_URL = config.get('PEER_URL')
+  const catalystUrls = [
+    PEER_URL + '/content',
+    ...catalystServers.map(server => server.address + '/content').filter(url => url !== PEER_URL + '/content')
+  ]
 
-    // Download required assets (body.png and face256.png are typically required)
-    const bodyFile = 'body.png'
-    const face256File = 'face256.png'
+  const MAX_ATTEMPTS = Math.min(catalystUrls.length, 3) // Try up to 3 catalysts or all available
 
-    const [bodyBuffer, faceBuffer] = await Promise.all([
-      client.downloadContent(contentHashesByFile[bodyFile]),
-      client.downloadContent(contentHashesByFile[face256File])
-    ])
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    const catalystUrl = catalystUrls[attempt]
 
-    // Prepare files map for deployment
-    const files = new Map<string, Uint8Array>()
-    files.set(bodyFile, new Uint8Array(bodyBuffer))
-    files.set(face256File, new Uint8Array(faceBuffer))
+    try {
+      await attemptRedeployment(entity, connectedAccount, connectedAccountIdentity, catalystUrl)
+      // If successful, exit the retry loop
+      console.log(`Profile redeployment successful using catalyst: ${catalystUrl}`)
+      return
+    } catch (error) {
+      const isLastAttempt = attempt === MAX_ATTEMPTS - 1
+      const shouldRetry = isLastAttempt ? false : isRetryableHttpError(error)
 
-    // Use existing profile metadata to preserve user customizations
-    const existingProfile = entity.metadata
+      console.warn(`Profile redeployment failed on catalyst ${catalystUrl} (attempt ${attempt + 1}/${MAX_ATTEMPTS}):`, error)
 
-    // Build deployment entity with fresh timestamp
-    const deploymentEntity = await DeploymentBuilder.buildEntity({
-      type: EntityType.PROFILE,
-      pointers: [connectedAccount],
-      metadata: existingProfile, // Preserve existing profile data
-      timestamp: Date.now(), // Only update timestamp for fresh deployment
-      files
-    })
+      if (isLastAttempt || !shouldRetry) {
+        if (isLastAttempt) {
+          console.error('Profile redeployment failed on all available catalysts')
+        }
+        throw error
+      }
 
-    // Deploy the profile using the user's ephemeral identity
-    await client.deploy({
-      entityId: deploymentEntity.entityId,
-      files: deploymentEntity.files,
-      authChain: Authenticator.signPayload(connectedAccountIdentity, deploymentEntity.entityId)
-    })
-  } catch (error) {
-    console.error('Failed to redeploy existing profile:', error)
-    throw error
+      // Small delay before trying next catalyst
+      await new Promise(resolve => setTimeout(resolve, 500))
+    }
   }
+}
+
+async function attemptRedeployment(
+  entity: Entity,
+  connectedAccount: string,
+  connectedAccountIdentity: AuthIdentity,
+  catalystUrl: string
+): Promise<void> {
+  const client = createContentClient({ url: catalystUrl, fetcher: createFetchComponent() })
+
+  // Extract file hashes from entity.content
+  const contentHashesByFile = entity.content.reduce((acc, next) => ({ ...acc, [next.file]: next.hash }), {} as Record<string, string>)
+
+  // Download required assets (body.png and face256.png are typically required)
+  const bodyFile = 'body.png'
+  const face256File = 'face256.png'
+
+  const [bodyBuffer, faceBuffer] = await Promise.all([
+    client.downloadContent(contentHashesByFile[bodyFile]),
+    client.downloadContent(contentHashesByFile[face256File])
+  ])
+
+  // Prepare files map for deployment
+  const files = new Map<string, Uint8Array>()
+  files.set(bodyFile, new Uint8Array(bodyBuffer))
+  files.set(face256File, new Uint8Array(faceBuffer))
+
+  // Use existing profile metadata to preserve user customizations
+  const existingProfile = entity.metadata
+
+  // Build deployment entity with fresh timestamp
+  const deploymentEntity = await DeploymentBuilder.buildEntity({
+    type: EntityType.PROFILE,
+    pointers: [connectedAccount],
+    metadata: existingProfile, // Preserve existing profile data
+    timestamp: Date.now(), // Only update timestamp for fresh deployment
+    files
+  })
+
+  // Deploy the profile using the user's ephemeral identity
+  await client.deploy({
+    entityId: deploymentEntity.entityId,
+    files: deploymentEntity.files,
+    authChain: Authenticator.signPayload(connectedAccountIdentity, deploymentEntity.entityId)
+  })
+}
+
+function isRetryableHttpError(error: unknown): boolean {
+  // Only retry on 5xx server errors or network issues
+  // Don't retry on 4xx client errors (bad request, auth issues, etc.)
+
+  if (!error) return true // Unknown error, try next catalyst
+
+  // Try to extract status code from various error formats
+  const errorObj = error as any
+  const statusCode = errorObj?.status || errorObj?.statusCode || errorObj?.response?.status
+
+  if (typeof statusCode === 'number') {
+    // Don't retry on 4xx client errors (400-499) - these are likely permanent
+    if (statusCode >= 400 && statusCode < 500) {
+      return false
+    }
+    // Retry on 5xx server errors (500-599) - these might work on another catalyst
+    if (statusCode >= 500) {
+      return true
+    }
+  }
+
+  // For all other errors (network, parsing, etc.), try next catalyst
+  return true
 }

--- a/src/modules/profile/index.ts
+++ b/src/modules/profile/index.ts
@@ -1,15 +1,80 @@
 import { createFetchComponent } from '@well-known-components/fetch-component'
-import { createLambdasClient } from 'dcl-catalyst-client'
+import { createLambdasClient, createContentClient } from 'dcl-catalyst-client'
 import { Profile } from 'dcl-catalyst-client/dist/client/specs/catalyst.schemas'
+import { getCatalystServersFromCache } from 'dcl-catalyst-client/dist/contracts-snapshots'
 import { config } from '../config'
+
+export interface ConsistencyResult {
+  isConsistent: boolean
+  profile?: Profile
+  error?: string
+}
 
 export async function fetchProfile(address: string): Promise<Profile | null> {
   const PEER_URL = config.get('PEER_URL')
   const client = createLambdasClient({ url: PEER_URL + '/lambdas', fetcher: createFetchComponent() })
   try {
-    const profile = await client.getAvatarDetails(address)
+    const profile: Profile = await client.getAvatarDetails(address)
     return profile
   } catch (error) {
     return null
+  }
+}
+
+export async function fetchProfileWithConsistencyCheck(address: string): Promise<ConsistencyResult> {
+  try {
+    // Determine network based on environment
+    const environment = config.get('ENVIRONMENT')
+    const network = environment === 'development' ? 'sepolia' : 'mainnet'
+
+    // Create content client for consistency check
+    const PEER_URL = config.get('PEER_URL')
+    const client = createContentClient({
+      url: PEER_URL + '/content',
+      fetcher: createFetchComponent()
+    })
+
+    // Get all catalyst servers for the network and remove the current peer to avoid duplicated fetches
+    const catalystServers = getCatalystServersFromCache(network)
+    const catalystUrls = catalystServers
+      .map(server => `${server.address}/content`)
+      .filter(url => url.toLowerCase() !== `${PEER_URL}/content`.toLowerCase())
+
+    // Check pointer consistency across all catalysts
+    const consistencyResult = await client.checkPointerConsistency(address, {
+      parallel: {
+        urls: catalystUrls
+      }
+    })
+
+    if (!consistencyResult.isConsistent) {
+      return {
+        isConsistent: false,
+        error: 'Profile is not consistent across catalysts'
+      }
+    }
+
+    // If consistent and we have up-to-date entities, extract profile
+    if (consistencyResult.upToDateEntities && consistencyResult.upToDateEntities.length > 0) {
+      // Extract profile from the first up-to-date entity's metadata
+      const entity = consistencyResult.upToDateEntities[0]
+      const profile = entity.metadata as Profile
+      return {
+        isConsistent: true,
+        profile: profile || undefined
+      }
+    }
+
+    // If no entities found, profile doesn't exist
+    return {
+      isConsistent: true,
+      profile: undefined
+    }
+  } catch (error) {
+    // If consistency check fails, we can't determine consistency, so redirect to onboarding
+    return {
+      isConsistent: false,
+      error: `Consistency check failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+    }
   }
 }


### PR DESCRIPTION
This PR adds fallbacks to be able to log-in users with inconsistency on their profile across many Catalysts.

## 📊 Flow Cases

### Case 1: Consistent & Complete Profile ✅
**Scenario**: Profile is consistent across all catalysts and complete
**Flow**: `Consistency Check → Profile Complete → Continue Login`
**Result**: Normal login flow, no intervention needed

### Case 2: Inconsistent Profile with Valid Entity 🔄
**Scenario**: Profile inconsistent across catalysts, but valid entity available
**Flow**: `Consistency Check → Inconsistent → Attempt Redeployment → Success → Continue Login`
**Result**: Transparent fix, user proceeds with login seamlessly

### Case 3: Inconsistent Profile - Redeployment Fails (even after retries)⚠️
**Scenario**: Profile inconsistent, valid entity available, but redeployment fails
**Flow**: `Consistency Check → Inconsistent → Attempt Redeployment → Fails → Onboarding Fallback`
**Result**: Graceful fallback to avatar setup or standard setup

### Case 4: Inconsistent Profile - No Valid Entity ❌
**Scenario**: Profile inconsistent across catalysts, no valid entity to redeploy
**Flow**: `Consistency Check → Inconsistent → No Entity → Direct Onboarding Fallback`
**Result**: Skip redeployment attempt, direct fallback to onboarding

### Case 5: Consistent but Incomplete Profile 📝
**Scenario**: Profile consistent across catalysts but missing required data
**Flow**: `Consistency Check → Consistent → Profile Incomplete → Onboarding`
**Result**: Redirect to appropriate setup flow (avatar setup or standard setup)

### Case 6: No Profile Exists 🆕
**Scenario**: No profile found on any catalyst
**Flow**: `Consistency Check → Consistent → No Entity → Onboarding`
**Result**: New user flow, redirect to profile creation