### PR TITLE
fix: show completion view when request was already fulfilled

### DIFF
--- a/src/components/Pages/RequestPage/RequestPage.spec.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.spec.tsx
@@ -342,13 +342,15 @@ describe('RequestPage', () => {
         mockRecover.mockRejectedValue(new RequestFulfilledError(REQUEST_ID))
       })
 
-      it('should not show any error view (request already consumed)', async () => {
+      it('should show sign-in complete view (request already consumed)', async () => {
         renderRequestPage()
         await waitFor(() => {
           expect(mockRecover).toHaveBeenCalled()
         })
-        // Should still show loading (no view change) — the fulfilled error is silently handled
-        expect(screen.getByTestId('loading-request')).toBeInTheDocument()
+        // Should show completion view — the request was already successfully consumed
+        await waitFor(() => {
+          expect(screen.getByTestId('sign-in-complete')).toBeInTheDocument()
+        })
       })
     })
 

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -402,6 +402,7 @@ export const RequestPage = () => {
         } else if (e instanceof RequestFulfilledError) {
           // Request was already consumed successfully — not an error, stop re-fetching
           hasCompletedRef.current = true
+          setView(View.VERIFY_SIGN_IN_COMPLETE)
           return
         }
 


### PR DESCRIPTION
## Summary

- When `LOGIN_ON_SETUP` is enabled, both SetupPage and AvatarSetupPage recover and sign the request during profile setup via `useSignRequest`. After setup completes, the user is redirected back to RequestPage, which calls `recover()` again on the already-consumed request.
- The server returns "already fulfilled", caught as `RequestFulfilledError`, but the handler only set `hasCompletedRef` without transitioning the view — leaving the user stuck on `LOADING_REQUEST` indefinitely.
- Transition to `VERIFY_SIGN_IN_COMPLETE` on `RequestFulfilledError` so the user sees the completion screen instead of an infinite spinner.

## Test plan

- [ ] Enable the `LOGIN_ON_SETUP` feature flag
- [ ] Use a new wallet to simulate first-time user
- [ ] Go through the standard setup flow (`/setup`) and verify the request page shows "Sign in complete" after redirect
- [ ] Go through the avatar setup flow (`/avatar-setup`) and verify the same
- [ ] Verify existing users (no setup redirect) are unaffected