### PR TITLE
feat: open explorer via deep link after social login

### DIFF
--- a/src/components/FeatureFlagsProvider/FeatureFlagsProvider.types.ts
+++ b/src/components/FeatureFlagsProvider/FeatureFlagsProvider.types.ts
@@ -8,7 +8,8 @@ enum FeatureFlagsKeys {
   UNITY_WEARABLE_PREVIEW = 'dapps-unity-wearable-preview',
   ONBOARDING_FLOW = 'dapps-onboarding-flow',
   DISABLED_CATALYSTS = 'explorer-disabled-catalyst',
-  SIGN_IN_PRIMARY_OPTION = 'dapps-sign-in-primary-option'
+  SIGN_IN_PRIMARY_OPTION = 'dapps-sign-in-primary-option',
+  OPEN_EXPLORER_AFTER_LOGIN = 'dapps-open-explorer-after-login'
 }
 
 enum OnboardingFlowVariant {

--- a/src/components/Pages/CallbackPage/CallbackPage.spec.tsx
+++ b/src/components/Pages/CallbackPage/CallbackPage.spec.tsx
@@ -1,0 +1,263 @@
+/* eslint-disable @typescript-eslint/naming-convention, import/order */
+import { BrowserRouter } from 'react-router-dom'
+import { render, waitFor } from '@testing-library/react'
+import type { AuthIdentity } from '@dcl/crypto'
+import { CallbackPage } from './CallbackPage'
+
+// --- Mocks ---
+
+const mockNavigate = jest.fn()
+jest.mock('../../../hooks/navigation', () => ({
+  useNavigateWithSearchParams: () => mockNavigate
+}))
+
+const mockRedirect = jest.fn()
+let mockRedirectUrl = 'https://decentraland.org/'
+jest.mock('../../../hooks/redirection', () => ({
+  useAfterLoginRedirection: () => ({ url: mockRedirectUrl, redirect: mockRedirect })
+}))
+
+const mockEnsureProfile = jest.fn()
+jest.mock('../../../hooks/useEnsureProfile', () => ({
+  useEnsureProfile: () => ({ ensureProfile: mockEnsureProfile })
+}))
+
+const mockTrackLoginSuccess = jest.fn().mockResolvedValue(undefined)
+jest.mock('../../../hooks/useAnalytics', () => ({
+  useAnalytics: () => ({ trackLoginSuccess: mockTrackLoginSuccess })
+}))
+
+jest.mock('../../../hooks/targetConfig', () => ({
+  useTargetConfig: () => [
+    {
+      skipSetup: true,
+      explorerText: 'Decentraland app',
+      connectionOptions: {}
+    },
+    'default'
+  ]
+}))
+
+const mockGetIdentitySignature = jest.fn()
+jest.mock('../../../shared/connection', () => ({
+  useCurrentConnectionData: () => ({
+    getIdentitySignature: mockGetIdentitySignature
+  })
+}))
+
+jest.mock('../../../shared/mobile', () => ({
+  isMobileSession: () => false
+}))
+
+const mockConnect = jest.fn()
+jest.mock('decentraland-connect', () => ({
+  connection: {
+    connect: (...args: unknown[]) => mockConnect(...args)
+  }
+}))
+
+const mockGetRedirectResult = jest.fn()
+jest.mock('../../../shared/utils/magicSdk', () => ({
+  OAUTH_ACCESS_DENIED_ERROR: 'access_denied',
+  createMagicInstance: () =>
+    Promise.resolve({
+      oauth2: { getRedirectResult: mockGetRedirectResult }
+    })
+}))
+
+const mockMarkReturningUser = jest.fn()
+jest.mock('../../../shared/onboarding/markReturningUser', () => ({
+  markReturningUser: (...args: unknown[]) => mockMarkReturningUser(...args)
+}))
+
+jest.mock('../../../shared/onboarding/getStoredEmail', () => ({
+  getStoredEmail: jest.fn().mockReturnValue(null)
+}))
+
+jest.mock('../../../shared/onboarding/trackCheckpoint', () => ({
+  trackCheckpoint: jest.fn()
+}))
+
+jest.mock('../../../shared/utils/errorHandler', () => ({
+  handleError: jest.fn()
+}))
+
+jest.mock('../../AnimatedBackground', () => ({
+  AnimatedBackground: () => <div data-testid="animated-background" />
+}))
+
+jest.mock('../../ConnectionModal/ConnectionLayout', () => ({
+  ConnectionLayout: ({ state }: { state: string }) => <div data-testid="connection-layout" data-state={state} />
+}))
+
+jest.mock('./CallbackPage.styled', () => {
+  const Div = ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => (
+    <div {...props}>{children}</div>
+  )
+  return { Container: Div, Wrapper: Div }
+})
+
+jest.mock('../MobileCallbackPage/MobileCallbackPage', () => ({
+  MobileCallbackPage: () => <div data-testid="mobile-callback" />
+}))
+
+jest.mock('../../FeatureFlagsProvider', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { createContext } = require('react')
+  return {
+    FeatureFlagsContext: createContext({
+      flags: {},
+      variants: {},
+      initialized: true
+    }),
+    FeatureFlagsKeys: {
+      MAGIC_TEST: 'dapps-magic-dev-test',
+      OPEN_EXPLORER_AFTER_LOGIN: 'dapps-open-explorer-after-login'
+    }
+  }
+})
+
+jest.mock('decentraland-ui2', () => ({
+  CircularProgress: () => null
+}))
+
+// --- Helpers ---
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { FeatureFlagsContext } = require('../../FeatureFlagsProvider')
+
+const createMockIdentity = (): AuthIdentity =>
+  ({
+    ephemeralIdentity: {
+      privateKey: '0x' + 'a'.repeat(64),
+      publicKey: '0x' + 'b'.repeat(130),
+      address: '0x' + 'c'.repeat(40)
+    },
+    expiration: new Date(Date.now() + 60_000),
+    authChain: []
+  }) as unknown as AuthIdentity
+
+interface RenderOptions {
+  flags?: Record<string, boolean>
+  redirectUrl?: string
+}
+
+const renderWithProviders = ({ flags = {}, redirectUrl = 'https://decentraland.org/' }: RenderOptions = {}) => {
+  mockRedirectUrl = redirectUrl
+  return render(
+    <BrowserRouter>
+      <FeatureFlagsContext.Provider value={{ flags, variants: {}, initialized: true }}>
+        <CallbackPage />
+      </FeatureFlagsContext.Provider>
+    </BrowserRouter>
+  )
+}
+
+// --- Tests ---
+
+describe('CallbackPage', () => {
+  beforeEach(() => {
+    mockGetRedirectResult.mockResolvedValue({ oauth: { userInfo: {} } })
+    mockConnect.mockResolvedValue({
+      account: '0xTestAccount',
+      provider: {},
+      providerType: 'magic'
+    })
+    mockGetIdentitySignature.mockResolvedValue(createMockIdentity())
+    mockTrackLoginSuccess.mockResolvedValue(undefined)
+    mockEnsureProfile.mockResolvedValue({ avatars: [{}] })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('when the OPEN_EXPLORER_AFTER_LOGIN flag is enabled', () => {
+    it('should navigate to the open explorer page', async () => {
+      renderWithProviders({ flags: { 'dapps-open-explorer-after-login': true } })
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('/open-explorer'), { replace: true })
+      })
+    })
+
+    it('should not call redirect', async () => {
+      renderWithProviders({ flags: { 'dapps-open-explorer-after-login': true } })
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('/open-explorer'), { replace: true })
+      })
+
+      expect(mockRedirect).not.toHaveBeenCalled()
+    })
+
+    it('should mark the user as returning', async () => {
+      renderWithProviders({ flags: { 'dapps-open-explorer-after-login': true } })
+
+      await waitFor(() => {
+        expect(mockMarkReturningUser).toHaveBeenCalledWith('0xTestAccount')
+      })
+    })
+  })
+
+  describe('when the OPEN_EXPLORER_AFTER_LOGIN flag is disabled', () => {
+    it('should not navigate to the open explorer page', async () => {
+      renderWithProviders()
+
+      await waitFor(() => {
+        expect(mockRedirect).toHaveBeenCalled()
+      })
+
+      expect(mockNavigate).not.toHaveBeenCalledWith(expect.stringContaining('/open-explorer'), expect.anything())
+    })
+
+    it('should call redirect', async () => {
+      renderWithProviders()
+
+      await waitFor(() => {
+        expect(mockRedirect).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('when the OPEN_EXPLORER_AFTER_LOGIN flag is enabled and redirectTo has an explicit path', () => {
+    it('should redirect instead of navigating to open explorer', async () => {
+      renderWithProviders({
+        flags: { 'dapps-open-explorer-after-login': true },
+        redirectUrl: 'https://decentraland.org/marketplace'
+      })
+
+      await waitFor(() => {
+        expect(mockRedirect).toHaveBeenCalled()
+      })
+
+      expect(mockNavigate).not.toHaveBeenCalledWith(expect.stringContaining('/open-explorer'), expect.anything())
+    })
+  })
+
+  describe('when the OAuth provider returns an access_denied error', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: { search: '?error=access_denied', href: 'http://localhost/auth/callback?error=access_denied' },
+        writable: true,
+        configurable: true
+      })
+    })
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        value: { search: '', href: 'http://localhost/auth/callback' },
+        writable: true,
+        configurable: true
+      })
+    })
+
+    it('should navigate back to the login page', async () => {
+      renderWithProviders()
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('/login'), { replace: true })
+      })
+    })
+  })
+})

--- a/src/components/Pages/CallbackPage/CallbackPage.tsx
+++ b/src/components/Pages/CallbackPage/CallbackPage.tsx
@@ -101,6 +101,13 @@ const DesktopCallbackPage = () => {
           type: ConnectionType.WEB2
         })
 
+        const hasExplicitRedirect = new URL(redirectTo, window.location.origin).pathname !== '/'
+        if (flags[FeatureFlagsKeys.OPEN_EXPLORER_AFTER_LOGIN] && !hasExplicitRedirect) {
+          markReturningUser(connectionData.account ?? '')
+          navigate(locations.openExplorer(), { replace: true })
+          return
+        }
+
         const account = connectionData.account ?? ''
 
         if (targetConfig && !targetConfig.skipSetup && account) {
@@ -117,7 +124,7 @@ const DesktopCallbackPage = () => {
         navigate(locations.login(), { replace: true })
       }
     },
-    [navigate, connectAndGenerateSignature, redirect, trackLoginSuccess, initialized, targetConfig?.skipSetup, redirectTo, ensureProfile]
+    [navigate, connectAndGenerateSignature, redirect, trackLoginSuccess, initialized, targetConfig?.skipSetup, redirectTo, ensureProfile, flags[FeatureFlagsKeys.OPEN_EXPLORER_AFTER_LOGIN]]
   )
 
   const logInAndRedirect = useCallback(async () => {

--- a/src/components/Pages/OpenExplorerPage/OpenExplorerPage.spec.tsx
+++ b/src/components/Pages/OpenExplorerPage/OpenExplorerPage.spec.tsx
@@ -1,0 +1,301 @@
+/* eslint-disable @typescript-eslint/naming-convention, import/order */
+import { act, render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { AuthIdentity } from '@dcl/crypto'
+import { localStorageGetIdentity } from '@dcl/single-sign-on-client'
+import { OpenExplorerPage } from './OpenExplorerPage'
+
+const mockLaunchDeepLink = jest.fn()
+jest.mock('../RequestPage/utils', () => ({
+  launchDeepLink: (...args: unknown[]) => mockLaunchDeepLink(...args)
+}))
+
+jest.mock('../../../modules/config', () => ({
+  config: {
+    get: (key: string) => {
+      if (key === 'ENVIRONMENT') return 'production'
+      return ''
+    }
+  }
+}))
+
+const mockNavigate = jest.fn()
+jest.mock('../../../hooks/navigation', () => ({
+  useNavigateWithSearchParams: () => mockNavigate
+}))
+
+jest.mock('../../../hooks/targetConfig', () => ({
+  useTargetConfig: () => [
+    {
+      explorerText: 'Decentraland app'
+    },
+    'default'
+  ]
+}))
+
+const mockPostIdentity = jest.fn()
+jest.mock('../../../shared/auth', () => ({
+  createAuthServerHttpClient: () => ({
+    postIdentity: mockPostIdentity
+  })
+}))
+
+let mockAccount: string | undefined = '0xTestAccount'
+jest.mock('../../../shared/connection', () => ({
+  useCurrentConnectionData: () => ({
+    get account() {
+      return mockAccount
+    }
+  })
+}))
+
+jest.mock('@dcl/single-sign-on-client', () => ({
+  localStorageGetIdentity: jest.fn()
+}))
+
+jest.mock('../../../shared/utils/errorHandler', () => ({
+  handleError: jest.fn()
+}))
+
+jest.mock('@dcl/hooks', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (key === 'mobile_auth.redirect_countdown') return `Opening ${params?.explorerText} in ${params?.countdown}...`
+      if (key === 'mobile_auth.redirecting') return `Redirecting to ${params?.explorerText}...`
+      if (key === 'mobile_auth.could_not_open') return `Could not open ${params?.explorerText}`
+      if (key === 'mobile_auth.return_to') return `Open ${params?.explorerText}`
+      if (key === 'connection_layout.validating_sign_in') return 'Verifying...'
+      if (key === 'common.try_again') return 'Try again'
+      return key
+    }
+  })
+}))
+
+jest.mock('../../AnimatedBackground', () => ({
+  AnimatedBackground: () => <div data-testid="animated-background" />
+}))
+
+jest.mock('./OpenExplorerPage.styled', () => {
+  const Div = ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => (
+    <div {...props}>{children}</div>
+  )
+  return { Container: Div, Wrapper: Div }
+})
+
+jest.mock('../../ConnectionModal/ConnectionLayout.styled', () => {
+  const Div = ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }) => (
+    <div {...props}>{children}</div>
+  )
+  return {
+    ConnectionContainer: Div,
+    ConnectionTitle: Div,
+    DecentralandLogo: () => <div data-testid="dcl-logo" />,
+    ErrorButtonContainer: Div,
+    ProgressContainer: Div
+  }
+})
+
+jest.mock('decentraland-ui2', () => ({
+  Button: ({
+    children,
+    onClick,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { variant?: string; children?: React.ReactNode }) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+  CircularProgress: () => <div data-testid="progress" />
+}))
+
+// --- Helpers ---
+
+const createMockIdentity = (): AuthIdentity =>
+  ({
+    ephemeralIdentity: {
+      privateKey: '0x' + 'a'.repeat(64),
+      publicKey: '0x' + 'b'.repeat(130),
+      address: '0x' + 'c'.repeat(40)
+    },
+    expiration: new Date(Date.now() + 60_000),
+    authChain: []
+  }) as unknown as AuthIdentity
+
+// --- Tests ---
+
+describe('OpenExplorerPage', () => {
+  const mockIdentity = createMockIdentity()
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    mockAccount = '0xTestAccount'
+    mockLaunchDeepLink.mockResolvedValue(true)
+    ;(localStorageGetIdentity as jest.Mock).mockReturnValue(mockIdentity)
+    mockPostIdentity.mockResolvedValue({ identityId: 'test-id-123' })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.clearAllMocks()
+  })
+
+  describe('when the account and identity are available', () => {
+    it('should post the identity to the auth server', async () => {
+      render(<OpenExplorerPage />)
+
+      await waitFor(() => {
+        expect(mockPostIdentity).toHaveBeenCalledWith(mockIdentity, { isMobile: false })
+      })
+    })
+
+    it('should show a countdown after posting the identity', async () => {
+      const { container } = render(<OpenExplorerPage />)
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Opening Decentraland app in 3...')
+      })
+    })
+
+    it('should attempt deep link after countdown', async () => {
+      const { container } = render(<OpenExplorerPage />)
+
+      // Wait for postIdentity to resolve and countdown to appear
+      await waitFor(() => {
+        expect(container.textContent).toContain('Opening Decentraland app in')
+      })
+
+      act(() => {
+        jest.advanceTimersByTime(3000)
+      })
+
+      await waitFor(() => {
+        expect(mockLaunchDeepLink).toHaveBeenCalledWith('decentraland://?dclenv=org&signin=test-id-123')
+      })
+    })
+  })
+
+  describe('when the deep link fails', () => {
+    beforeEach(() => {
+      mockLaunchDeepLink.mockResolvedValue(false)
+    })
+
+    it('should show both retry and go back buttons', async () => {
+      const { container, getByTestId } = render(<OpenExplorerPage />)
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Opening Decentraland app in')
+      })
+
+      act(() => {
+        jest.advanceTimersByTime(3000)
+      })
+
+      await waitFor(() => {
+        expect(getByTestId('open-explorer-retry-button')).toBeTruthy()
+        expect(getByTestId('open-explorer-go-back-button')).toBeTruthy()
+      })
+    })
+
+    it('should navigate to login when go back is clicked', async () => {
+      const { container, getByTestId } = render(<OpenExplorerPage />)
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Opening Decentraland app in')
+      })
+
+      // Advance timers and flush the async launchDeepLink promise
+      await act(async () => {
+        jest.advanceTimersByTime(3000)
+      })
+
+      await waitFor(() => {
+        expect(getByTestId('open-explorer-go-back-button')).toBeTruthy()
+      })
+
+      getByTestId('open-explorer-go-back-button').click()
+
+      expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('/login'), { replace: true })
+    })
+
+    it('should restart the countdown when retry is clicked', async () => {
+      mockLaunchDeepLink.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      const { container, getByTestId } = render(<OpenExplorerPage />)
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Opening Decentraland app in')
+      })
+
+      act(() => {
+        jest.advanceTimersByTime(3000)
+      })
+
+      await waitFor(() => {
+        expect(getByTestId('open-explorer-retry-button')).toBeTruthy()
+      })
+
+      await user.click(getByTestId('open-explorer-retry-button'))
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Opening Decentraland app in 3...')
+      })
+    })
+  })
+
+  describe('when no account is available', () => {
+    beforeEach(() => {
+      mockAccount = undefined
+    })
+
+    it('should navigate to the login page', async () => {
+      render(<OpenExplorerPage />)
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('/login'), { replace: true })
+      })
+    })
+  })
+
+  describe('when identity is not in localStorage', () => {
+    beforeEach(() => {
+      ;(localStorageGetIdentity as jest.Mock).mockReturnValue(null)
+    })
+
+    it('should navigate to the login page', async () => {
+      render(<OpenExplorerPage />)
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('/login'), { replace: true })
+      })
+    })
+  })
+
+  describe('when postIdentity fails', () => {
+    beforeEach(() => {
+      mockPostIdentity.mockRejectedValue(new Error('Server error'))
+    })
+
+    it('should show an error state with a go back to login button', async () => {
+      const { getByTestId } = render(<OpenExplorerPage />)
+
+      await waitFor(() => {
+        expect(getByTestId('open-explorer-go-back-button')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('when the open explorer button is clicked', () => {
+    it('should attempt to launch the deep link', async () => {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
+      const { container, getByTestId } = render(<OpenExplorerPage />)
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Opening Decentraland app in')
+      })
+
+      await user.click(getByTestId('open-explorer-button'))
+
+      expect(mockLaunchDeepLink).toHaveBeenCalledWith('decentraland://?dclenv=org&signin=test-id-123')
+    })
+  })
+})

--- a/src/components/Pages/OpenExplorerPage/OpenExplorerPage.styled.ts
+++ b/src/components/Pages/OpenExplorerPage/OpenExplorerPage.styled.ts
@@ -1,0 +1,19 @@
+import { Box, styled } from 'decentraland-ui2'
+
+const Container = styled(Box)({
+  display: 'flex',
+  height: '100vh',
+  width: '100vw',
+  position: 'relative'
+})
+
+const Wrapper = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  height: '100%',
+  width: '100%'
+})
+
+export { Container, Wrapper }

--- a/src/components/Pages/OpenExplorerPage/OpenExplorerPage.tsx
+++ b/src/components/Pages/OpenExplorerPage/OpenExplorerPage.tsx
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from '@dcl/hooks'
+import { localStorageGetIdentity } from '@dcl/single-sign-on-client'
+import { Button, CircularProgress } from 'decentraland-ui2'
+import { useNavigateWithSearchParams } from '../../../hooks/navigation'
+import { useTargetConfig } from '../../../hooks/targetConfig'
+import { config } from '../../../modules/config'
+import { createAuthServerHttpClient } from '../../../shared/auth'
+import { useCurrentConnectionData } from '../../../shared/connection'
+import { locations } from '../../../shared/locations'
+import { handleError } from '../../../shared/utils/errorHandler'
+import { AnimatedBackground } from '../../AnimatedBackground'
+import {
+  ConnectionContainer,
+  ConnectionTitle,
+  DecentralandLogo,
+  ErrorButtonContainer,
+  ProgressContainer
+} from '../../ConnectionModal/ConnectionLayout.styled'
+import { launchDeepLink } from '../RequestPage/utils'
+import { Container, Wrapper } from './OpenExplorerPage.styled'
+
+const COUNTDOWN_SECONDS = 3
+
+const ENVIRONMENT_TO_DCLENV: Record<string, string> = {
+  development: 'zone',
+  staging: 'today',
+  production: 'org'
+}
+
+export const OpenExplorerPage = () => {
+  const { t } = useTranslation()
+  const navigate = useNavigateWithSearchParams()
+  const [targetConfig] = useTargetConfig()
+  const { account } = useCurrentConnectionData()
+  const hasStartedPosting = useRef(false)
+
+  const [identityId, setIdentityId] = useState<string | null>(null)
+  const [countdown, setCountdown] = useState(COUNTDOWN_SECONDS)
+  const [deepLinkFailed, setDeepLinkFailed] = useState(false)
+  const [error, setError] = useState(false)
+
+  const explorerText = targetConfig.explorerText
+
+  const environment = config.get('ENVIRONMENT').toLowerCase()
+  const dclenv = ENVIRONMENT_TO_DCLENV[environment]
+  if (!dclenv) {
+    console.warn('Unknown ENVIRONMENT value for deep link:', environment, '— defaulting to org')
+  }
+
+  // Post the identity to the auth server on mount
+  useEffect(() => {
+    if (hasStartedPosting.current) return
+    hasStartedPosting.current = true
+
+    const postCurrentIdentity = async () => {
+      const ethAddress = account?.toLowerCase()
+      if (!ethAddress) {
+        navigate(locations.login(), { replace: true })
+        return
+      }
+
+      const identity = localStorageGetIdentity(ethAddress)
+      if (!identity) {
+        console.warn('No identity found in localStorage for', ethAddress)
+        navigate(locations.login(), { replace: true })
+        return
+      }
+
+      try {
+        const httpClient = createAuthServerHttpClient()
+        const response = await httpClient.postIdentity(identity, { isMobile: false })
+        setIdentityId(response.identityId)
+      } catch (err) {
+        handleError(err, 'Error posting identity to auth server')
+        setError(true)
+      }
+    }
+
+    postCurrentIdentity()
+  }, [account, navigate])
+
+  const deepLinkUrl = identityId ? `decentraland://?dclenv=${dclenv ?? 'org'}&signin=${identityId}` : null
+
+  const attemptDeepLink = useCallback(async () => {
+    if (!deepLinkUrl) return
+    const wasLaunched = await launchDeepLink(deepLinkUrl)
+    if (!wasLaunched) {
+      setDeepLinkFailed(true)
+    }
+  }, [deepLinkUrl])
+
+  const handleRetryDeepLink = useCallback(() => {
+    setDeepLinkFailed(false)
+    setCountdown(COUNTDOWN_SECONDS)
+  }, [])
+
+  const handleGoBackToLogin = useCallback(() => {
+    navigate(locations.login(), { replace: true })
+  }, [navigate])
+
+  // Countdown and auto-launch deep link after identity is posted
+  useEffect(() => {
+    if (!identityId || deepLinkFailed) return
+
+    const interval = setInterval(() => {
+      setCountdown(prev => {
+        if (prev <= 1) {
+          clearInterval(interval)
+          attemptDeepLink()
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+
+    return () => clearInterval(interval)
+  }, [identityId, deepLinkFailed, attemptDeepLink])
+
+  if (error) {
+    return (
+      <Container>
+        <AnimatedBackground variant="absolute" />
+        <Wrapper>
+          <ConnectionContainer>
+            <DecentralandLogo size="huge" />
+            <ConnectionTitle>{t('mobile_auth.could_not_open', { explorerText })}</ConnectionTitle>
+            <ErrorButtonContainer>
+              <Button variant="contained" onClick={handleGoBackToLogin} data-testid="open-explorer-go-back-button">
+                {t('request.go_back_login')}
+              </Button>
+            </ErrorButtonContainer>
+          </ConnectionContainer>
+        </Wrapper>
+      </Container>
+    )
+  }
+
+  if (!identityId) {
+    return (
+      <Container>
+        <AnimatedBackground variant="absolute" />
+        <Wrapper>
+          <ConnectionContainer>
+            <DecentralandLogo size="huge" />
+            <ConnectionTitle>{t('connection_layout.validating_sign_in')}</ConnectionTitle>
+            <ProgressContainer>
+              <CircularProgress color="inherit" />
+            </ProgressContainer>
+          </ConnectionContainer>
+        </Wrapper>
+      </Container>
+    )
+  }
+
+  return (
+    <Container>
+      <AnimatedBackground variant="absolute" />
+      <Wrapper>
+        <ConnectionContainer>
+          <DecentralandLogo size="huge" />
+          {deepLinkFailed ? (
+            <>
+              <ConnectionTitle>{t('mobile_auth.could_not_open', { explorerText })}</ConnectionTitle>
+              <ErrorButtonContainer>
+                <Button variant="contained" onClick={handleRetryDeepLink} data-testid="open-explorer-retry-button">
+                  {t('common.try_again')}
+                </Button>
+                <Button variant="outlined" onClick={handleGoBackToLogin} data-testid="open-explorer-go-back-button">
+                  {t('request.go_back_login')}
+                </Button>
+              </ErrorButtonContainer>
+            </>
+          ) : (
+            <>
+              <ConnectionTitle>
+                {countdown > 0
+                  ? t('mobile_auth.redirect_countdown', { explorerText, countdown })
+                  : t('mobile_auth.redirecting', { explorerText })}
+              </ConnectionTitle>
+              <ProgressContainer>
+                <CircularProgress color="inherit" />
+              </ProgressContainer>
+              <Button variant="contained" onClick={attemptDeepLink} data-testid="open-explorer-button">
+                {t('mobile_auth.return_to', { explorerText })}
+              </Button>
+            </>
+          )}
+        </ConnectionContainer>
+      </Wrapper>
+    </Container>
+  )
+}

--- a/src/components/Pages/OpenExplorerPage/index.ts
+++ b/src/components/Pages/OpenExplorerPage/index.ts
@@ -1,0 +1,1 @@
+export { OpenExplorerPage } from './OpenExplorerPage'

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,6 +18,7 @@ import { InvalidRedirectionPage } from './components/Pages/InvalidRedirectionPag
 import { LoginPage } from './components/Pages/LoginPage'
 import { MobileAuthPage } from './components/Pages/MobileAuthPage'
 import { MobileCallbackPage } from './components/Pages/MobileCallbackPage'
+import { OpenExplorerPage } from './components/Pages/OpenExplorerPage'
 import { FeatureFlagsProvider } from './components/FeatureFlagsProvider'
 import { ConnectionProvider } from './shared/connection'
 import { config } from './modules/config'
@@ -84,6 +85,7 @@ const SiteRoutes = () => {
           }
         />
       ) : null}
+      <Route path="/open-explorer" Component={OpenExplorerPage} />
       <Route path="/setup" Component={SetupPage} />
       <Route path="/avatar-setup" Component={AvatarSetupPage} />
       <Route path="/mobile" Component={MobileAuthPage} />

--- a/src/shared/locations.ts
+++ b/src/shared/locations.ts
@@ -73,6 +73,7 @@ const locations = {
     `/avatar-setup${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}${
       referrer ? `${redirectTo ? '&' : '?'}referrer=${encodeURIComponent(referrer)}` : ''
     }`,
+  openExplorer: () => '/open-explorer',
   mobile: (provider?: string) => `/mobile${provider ? `?provider=${encodeURIComponent(provider)}` : ''}`,
   mobileCallback: () => '/mobile/callback'
 }


### PR DESCRIPTION
## Summary

When a user logs in via an OAuth provider (Google, Discord, etc.) and returns to `/auth/callback`, they currently get redirected to the `redirectTo` URL. When no explicit redirect destination is set and the `OPEN_EXPLORER_AFTER_LOGIN` feature flag (`dapps-open-explorer-after-login`) is enabled, the callback now navigates to a new `/auth/open-explorer` page that posts the identity to the auth server and opens the explorer via a deep link.

## How it works

### CallbackPage changes
After successful login in `handleContinue`, checks whether `OPEN_EXPLORER_AFTER_LOGIN` is enabled and no explicit `redirectTo` path was provided (pathname is `/`). If both conditions hold, marks the user as returning and navigates to `/open-explorer` with history replace. Otherwise, the existing redirect flow proceeds unchanged.

### OpenExplorerPage (new, self-contained)
1. Reads `account` from `ConnectionProvider` context (persists across navigation)
2. Gets the identity from `localStorageGetIdentity(account)`
3. Posts it to the auth server via `postIdentity` endpoint
4. Constructs a deep link: `decentraland://?dclenv={env}&signin={identityId}` where env is `zone`/`today`/`org` for dev/stg/prod
5. Shows a 3-second countdown, then attempts to launch the deep link
6. On deep link failure: shows "Try again" (retries with fresh countdown) and "Go back to login" buttons
7. On `postIdentity` failure or missing account/identity: shows error with "Go back to login"

### Feature flag
`OPEN_EXPLORER_AFTER_LOGIN` (`dapps-open-explorer-after-login`) — when disabled (default), behavior is completely unchanged.

## Test plan

- [ ] With flag enabled + no redirectTo: complete OAuth login → callback navigates to /open-explorer → shows countdown → launches deep link
- [ ] With flag enabled + redirectTo=/marketplace: callback redirects to /marketplace as usual
- [ ] With flag disabled: callback redirects as before (no behavior change)
- [ ] Deep link fails: shows "Try again" + "Go back to login" buttons
- [ ] "Try again" restarts the countdown and re-attempts the deep link
- [ ] "Go back to login" navigates to /login
- [ ] No account in context: redirects to /login