### PR TITLE
feat: add Thirdweb email OTP and Apple test auth to mobile flow

### DIFF
--- a/src/components/Pages/MobileAuthPage/MobileAuthPage.styled.ts
+++ b/src/components/Pages/MobileAuthPage/MobileAuthPage.styled.ts
@@ -4,29 +4,19 @@ const Main = styled(Box)({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  justifyContent: 'flex-start',
-  height: '100dvh',
-  maxHeight: '100dvh',
+  justifyContent: 'center',
+  minHeight: '100dvh',
   width: '100%',
   position: 'relative',
-  overflow: 'hidden',
-  padding: '20vh 20px 0',
+  overflowX: 'hidden',
+  padding: '40px 20px',
   boxSizing: 'border-box',
   ['&::before']: {
     content: '""',
     position: 'fixed',
-    width: '100%',
-    height: '350%',
-    background: 'radial-gradient(ellipse at 0 50%, transparent 10%, #e02dd3 40%, #491975 70%)',
-    top: '-100%',
-    transform: 'rotate(180deg)',
-    overflow: 'hidden',
+    inset: 0,
+    background: 'radial-gradient(71.22% 102.85% at 50.08% 77.11%, #7434B1 0%, #481C6C 37.11%, #2B1040 100%)',
     zIndex: -1
-  },
-  ['@media screen and (max-width: 800px)']: {
-    ['&::before']: {
-      background: 'radial-gradient(ellipse at 0 50%, #e02dd3 0%, #491975 70%)'
-    }
   }
 })
 
@@ -51,9 +41,12 @@ const MobileConnectionWrapper = styled(Box)({
   ['& > div > div:nth-of-type(2)']: {
     marginTop: '24px !important'
   },
-  // Target Title inside MainContentContainer
+  // Target Title inside MainContentContainer — shrink so the long copy
+  // ("Log in or Sign up to Jump In") fits on a single line on narrow phones.
   ['& > div > div:nth-of-type(2) > p:first-of-type']: {
-    marginBottom: '32px !important'
+    marginBottom: '32px !important',
+    fontSize: 'clamp(20px, 5.8vw, 24px) !important',
+    lineHeight: '1.3 !important'
   },
   // Target ShowMoreContainer (3rd child of ConnectionContainer)
   ['& > div > div:nth-of-type(3)']: {

--- a/src/components/Pages/MobileAuthPage/MobileAuthPage.tsx
+++ b/src/components/Pages/MobileAuthPage/MobileAuthPage.tsx
@@ -1,8 +1,11 @@
 import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
+import { useTranslation } from '@dcl/hooks'
+import { connection } from 'decentraland-connect'
 import { useTargetConfig } from '../../../hooks/targetConfig'
 import { createAuthServerHttpClient } from '../../../shared/auth'
 import { isErrorWithName } from '../../../shared/errors'
+import { disconnectWallet, sendEmailOTP } from '../../../shared/thirdweb'
 import { handleError } from '../../../shared/utils/errorHandler'
 import { createMagicInstance } from '../../../shared/utils/magicSdk'
 import { ConnectionOptionType } from '../../Connection'
@@ -12,13 +15,17 @@ import { FeatureFlagsContext, FeatureFlagsKeys } from '../../FeatureFlagsProvide
 import { connectToProvider, connectToSocialProvider, fromConnectionOptionToProviderType, isSocialLogin } from '../LoginPage/utils'
 import { getIdentitySignature } from './identityUtils'
 import { MobileAuthSuccess } from './MobileAuthSuccess'
+import { MobileEmailLoginModal } from './MobileEmailLoginModal'
+import { EmailLoginResult } from './MobileEmailLoginModal/MobileEmailLoginModal.types'
 import { MobileProviderSelection } from './MobileProviderSelection'
+import { isTestAuthEmail, sendTestAuthCode } from './testAuth'
 import { parseConnectionOptionType } from './utils'
 import { Main } from './MobileAuthPage.styled'
 
 type MobileAuthView = 'selection' | 'connecting' | 'success' | 'error'
 
 export const MobileAuthPage = () => {
+  const { t } = useTranslation()
   const [searchParams] = useSearchParams()
   const { flags, initialized: flagInitialized } = useContext(FeatureFlagsContext)
   const [targetConfig] = useTargetConfig()
@@ -31,6 +38,13 @@ export const MobileAuthPage = () => {
   const [loadingState, setLoadingState] = useState(provider ? ConnectionLayoutState.LOADING_MAGIC : ConnectionLayoutState.CONNECTING_WALLET)
   const [identityId, setIdentityId] = useState<string | null>(null)
   const [connectionType, setConnectionType] = useState<ConnectionOptionType | undefined>(provider ?? undefined)
+
+  // Email login state
+  const [currentEmail, setCurrentEmail] = useState('')
+  const [isEmailLoading, setIsEmailLoading] = useState(false)
+  const [emailError, setEmailError] = useState<string | null>(null)
+  const [showEmailLoginModal, setShowEmailLoginModal] = useState(false)
+  const [isTestAuthSession, setIsTestAuthSession] = useState(false)
 
   const hasStartedInit = useRef(false)
 
@@ -103,6 +117,10 @@ export const MobileAuthPage = () => {
 
         localStorage.removeItem('dcl_magic_user_email')
 
+        // Clear any Thirdweb in-app wallet session so each visit starts fresh.
+        await disconnectWallet()
+        localStorage.removeItem('dcl_thirdweb_user_email')
+
         const keysToRemove: string[] = []
         for (let i = 0; i < localStorage.length; i++) {
           const key = localStorage.key(i)
@@ -134,10 +152,130 @@ export const MobileAuthPage = () => {
     }
   }, [connectionType, initiateAuth])
 
+  const handleEmailInputChange = useCallback(() => {
+    setEmailError(null)
+  }, [])
+
+  const handleEmailSubmit = useCallback(
+    async (email: string) => {
+      setCurrentEmail(email)
+      setIsEmailLoading(true)
+      setEmailError(null)
+      setConnectionType(ConnectionOptionType.EMAIL)
+
+      // Best-effort cleanup of any stale connection from a previous session.
+      try {
+        await connection.disconnect()
+        await disconnectWallet()
+      } catch {
+        // Keep the flow going even if cleanup fails.
+      }
+
+      try {
+        // For emails matching the test domain, try the test auth backend first.
+        // If the backend rejects the specific email (403), fall back to Thirdweb.
+        let useTestAuth = false
+        if (isTestAuthEmail(email)) {
+          useTestAuth = await sendTestAuthCode(email)
+        }
+        if (!useTestAuth) {
+          await sendEmailOTP(email)
+        }
+        setIsTestAuthSession(useTestAuth)
+        setShowEmailLoginModal(true)
+      } catch (error) {
+        const errorMessage = handleError(error, 'Error sending verification code', {
+          sentryTags: {
+            connectionType: ConnectionOptionType.EMAIL,
+            isMobileFlow: true
+          }
+        })
+        // Clear connection type so other login options aren't disabled
+        setConnectionType(undefined)
+        if (errorMessage === 'Failed to fetch' || errorMessage?.toLowerCase().includes('network')) {
+          setEmailError(t('login.errors.network_error'))
+        } else if (errorMessage?.toLowerCase().includes('invalid email')) {
+          setEmailError(t('login.errors.invalid_email'))
+        } else {
+          setEmailError(errorMessage || t('login.errors.failed_send_code'))
+        }
+      } finally {
+        setIsEmailLoading(false)
+      }
+    },
+    [t]
+  )
+
+  const handleEmailLoginDismiss = useCallback(() => {
+    setShowEmailLoginModal(false)
+    setCurrentEmail('')
+    setConnectionType(undefined)
+  }, [])
+
+  const handleEmailLoginSuccess = useCallback(async (result: EmailLoginResult) => {
+    setShowEmailLoginModal(false)
+    setView('connecting')
+    setLoadingState(ConnectionLayoutState.WAITING_FOR_SIGNATURE)
+
+    try {
+      const address = result.address.toLowerCase()
+      let identity
+
+      if (result.identity) {
+        // Test auth flow: identity was generated server-side by mobile-bff
+        identity = result.identity
+      } else {
+        // Normal Thirdweb flow: restore the EIP-1193 provider that
+        // verifyEmailOTPAndConnect persisted via storeConnectionData(THIRDWEB, MAINNET).
+        const connectionData = await connection.tryPreviousConnection()
+        identity = await getIdentitySignature(address, connectionData.provider)
+      }
+
+      setLoadingState(ConnectionLayoutState.VALIDATING_SIGN_IN)
+      const httpClient = createAuthServerHttpClient()
+      const response = await httpClient.postIdentity(identity, { isMobile: true })
+
+      setIdentityId(response.identityId)
+      setView('success')
+    } catch (err) {
+      handleError(err, 'Error during mobile email auth', {
+        sentryTags: {
+          connectionType: ConnectionOptionType.EMAIL,
+          isMobileFlow: true
+        }
+      })
+
+      if (isErrorWithName(err) && err.name === 'ErrorUnlockingWallet') {
+        setLoadingState(ConnectionLayoutState.ERROR_LOCKED_WALLET)
+      } else {
+        setLoadingState(ConnectionLayoutState.ERROR)
+      }
+      setView('error')
+    }
+  }, [])
+
   // Provider selection view
   if (view === 'selection') {
     return (
-      <MobileProviderSelection onConnect={initiateAuth} loadingOption={connectionType} connectionOptions={targetConfig.connectionOptions} />
+      <>
+        <MobileProviderSelection
+          onConnect={initiateAuth}
+          loadingOption={connectionType}
+          connectionOptions={targetConfig.connectionOptions}
+          onEmailSubmit={handleEmailSubmit}
+          onEmailChange={handleEmailInputChange}
+          isEmailLoading={isEmailLoading}
+          emailError={emailError}
+        />
+        <MobileEmailLoginModal
+          open={showEmailLoginModal}
+          email={currentEmail}
+          isTestAuth={isTestAuthSession}
+          onClose={handleEmailLoginDismiss}
+          onBack={handleEmailLoginDismiss}
+          onSuccess={handleEmailLoginSuccess}
+        />
+      </>
     )
   }
 

--- a/src/components/Pages/MobileAuthPage/MobileEmailLoginModal/MobileEmailLoginModal.styled.ts
+++ b/src/components/Pages/MobileAuthPage/MobileEmailLoginModal/MobileEmailLoginModal.styled.ts
@@ -1,0 +1,305 @@
+/* eslint-disable @typescript-eslint/naming-convention -- CSS selectors, keyframes, and pseudo-elements use non-camelCase */
+import { Box, CircularProgress, Dialog, keyframes, styled } from 'decentraland-ui2'
+
+/**
+ * Class name applied to the OTP Dialog root.
+ * MUI Dialog does not expose a way to style its internal .MuiDialog-container (the scroll wrapper
+ * that sits between the backdrop and the paper). By passing this class to the Dialog and
+ * targeting `.MuiDialog-container` in global styles, we can apply the dark overlay to the full
+ * viewport so page content does not show through.
+ */
+const OTP_MODAL_ROOT_CLASS = 'otp-modal-root'
+
+/**
+ * Global styles for the OTP modal's dialog container.
+ * Rendered via MUI GlobalStyles in MobileEmailLoginModal; applies a semi-transparent dark overlay
+ * to the container so the backdrop covers the whole screen consistently.
+ */
+const otpModalContainerGlobalStyles = {
+  [`.${OTP_MODAL_ROOT_CLASS} .MuiDialog-container`]: {
+    background: 'rgba(0, 0, 0, 0.6)',
+    position: 'fixed',
+    inset: 0
+  }
+}
+
+const shake = keyframes({
+  '0%, 100%': { transform: 'translateX(0)' },
+  '10%, 30%, 50%, 70%, 90%': { transform: 'translateX(-6px)' },
+  '20%, 40%, 60%, 80%': { transform: 'translateX(6px)' }
+})
+
+const StyledDialog = styled(Dialog)(({ theme }) => ({
+  '& .MuiDialog-paper': {
+    background: 'linear-gradient(135deg, #952dc6 0%, #32134c 100%)',
+    borderRadius: '16px',
+    maxWidth: '480px',
+    margin: 'auto',
+    [theme.breakpoints.down('md')]: {
+      width: '90%',
+      maxWidth: '400px',
+      minWidth: 'auto',
+      minHeight: 'auto',
+      height: 'auto',
+      margin: 'auto',
+      borderRadius: '16px',
+      top: 'auto',
+      padding: 0
+    },
+    [theme.breakpoints.down('sm')]: {
+      width: '90%',
+      maxWidth: '360px'
+    }
+  },
+  '& .MuiBackdrop-root': {
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    position: 'fixed',
+    inset: 0
+  }
+}))
+
+const Header = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: theme.spacing(2, 2.5)
+}))
+
+const BackButton = styled('button')(({ theme }) => ({
+  background: 'none',
+  border: 'none',
+  color: 'white',
+  fontSize: '14px',
+  fontWeight: 600,
+  cursor: 'pointer',
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+  padding: theme.spacing(1, 1.5),
+  transition: 'opacity 0.2s',
+  '&:hover:not(:disabled)': { opacity: 0.8 },
+  '&:disabled': { opacity: 0.5, cursor: 'not-allowed' }
+}))
+
+const BackIcon = styled('span')({
+  fontSize: 20,
+  lineHeight: 1
+})
+
+const CloseButton = styled('button')(({ theme }) => ({
+  background: 'none',
+  border: 'none',
+  color: 'white',
+  fontSize: 28,
+  cursor: 'pointer',
+  padding: theme.spacing(0.5, 1.5),
+  lineHeight: 1,
+  transition: 'opacity 0.2s',
+  '&:hover:not(:disabled)': { opacity: 0.8 },
+  '&:disabled': { opacity: 0.5, cursor: 'not-allowed' }
+}))
+
+const Main = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(0, 5, 5),
+  [theme.breakpoints.down('sm')]: {
+    padding: theme.spacing(0, 3, 4)
+  }
+}))
+
+const Content = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  textAlign: 'center'
+})
+
+const EmailIconContainer = styled(Box)(({ theme }) => ({
+  width: 100,
+  height: 100,
+  borderRadius: '50%',
+  background: 'rgba(255, 255, 255, 0.15)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  marginBottom: theme.spacing(3),
+  [theme.breakpoints.down('sm')]: {
+    width: 80,
+    height: 80,
+    marginBottom: theme.spacing(2.5)
+  }
+}))
+
+const EmailIcon = styled('img')(({ theme }) => ({
+  width: 48,
+  height: 48,
+  display: 'block',
+  filter: 'brightness(0) invert(1)',
+  [theme.breakpoints.down('sm')]: {
+    width: 40,
+    height: 40
+  }
+}))
+
+const Title = styled('p')(({ theme }) => ({
+  color: 'white',
+  fontSize: 28,
+  fontWeight: 600,
+  margin: 0,
+  marginBottom: theme.spacing(1.5),
+  [theme.breakpoints.down('sm')]: {
+    fontSize: 22
+  }
+}))
+
+const Subtitle = styled('p')(({ theme }) => ({
+  color: 'rgba(255, 255, 255, 0.85)',
+  fontSize: 14,
+  lineHeight: 1.5,
+  margin: 0,
+  marginBottom: theme.spacing(4),
+  maxWidth: 340,
+  '& strong': {
+    color: 'white',
+    fontWeight: 600
+  },
+  [theme.breakpoints.down('sm')]: {
+    fontSize: 13
+  }
+}))
+
+const OtpContainer = styled(Box, {
+  shouldForwardProp: prop => prop !== 'hasError'
+})<{ hasError?: boolean }>(({ theme, hasError }) => ({
+  display: 'flex',
+  gap: theme.spacing(1.5),
+  marginBottom: theme.spacing(3),
+  ...(hasError && {
+    animation: `${shake} 0.5s ease-in-out`
+  }),
+  [theme.breakpoints.down('sm')]: {
+    gap: theme.spacing(1)
+  }
+}))
+
+const OtpInput = styled('input', {
+  shouldForwardProp: prop => prop !== 'hasError'
+})<{ hasError?: boolean }>(({ theme, hasError }) => ({
+  width: 52,
+  height: 60,
+  border: `2px solid ${hasError ? '#ff4444' : 'rgba(255, 255, 255, 0.3)'}`,
+  borderRadius: 12,
+  background: hasError ? 'rgba(255, 68, 68, 0.1)' : 'transparent',
+  color: 'white',
+  fontSize: 24,
+  fontWeight: 600,
+  textAlign: 'center',
+  outline: 'none',
+  transition: 'border-color 0.2s, background-color 0.2s',
+  '&:focus': {
+    borderColor: 'white',
+    background: 'rgba(255, 255, 255, 0.1)'
+  },
+  '&:disabled': {
+    opacity: 0.5,
+    cursor: 'not-allowed'
+  },
+  '&::placeholder': {
+    color: 'rgba(255, 255, 255, 0.3)'
+  },
+  [theme.breakpoints.down('sm')]: {
+    width: 42,
+    height: 50,
+    fontSize: 20,
+    borderRadius: 10
+  }
+}))
+
+const VerifyingContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: theme.spacing(1),
+  marginBottom: theme.spacing(2)
+}))
+
+const VerifyingLoader = styled(CircularProgress)({
+  '&.MuiCircularProgress-root': {
+    color: 'white'
+  }
+})
+
+const VerifyingText = styled('span')({
+  color: 'rgba(255, 255, 255, 0.85)',
+  fontSize: 14
+})
+
+const ErrorMessage = styled('p')(({ theme }) => ({
+  color: '#ff6b6b',
+  fontSize: 14,
+  margin: 0,
+  marginBottom: theme.spacing(2),
+  '&::before': {
+    content: '"\\26A0"',
+    marginRight: theme.spacing(0.75)
+  }
+}))
+
+const ResendText = styled('p')(({ theme }) => ({
+  color: 'rgba(255, 255, 255, 0.7)',
+  fontSize: 14,
+  margin: theme.spacing(1, 0, 0)
+}))
+
+const ResendLink = styled('span', {
+  shouldForwardProp: prop => prop !== 'disabled'
+})<{ disabled?: boolean }>(({ theme, disabled }) => ({
+  color: theme.palette.primary.main,
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  textDecoration: 'underline',
+  transition: 'color 0.2s, opacity 0.2s',
+  opacity: disabled ? 0.5 : 1,
+  pointerEvents: disabled ? 'none' : 'auto',
+  '&:hover': {
+    color: disabled ? theme.palette.primary.main : '#ffb3b3'
+  }
+}))
+
+const ResendLinkError = styled('span', {
+  shouldForwardProp: prop => prop !== 'disabled'
+})<{ disabled?: boolean }>(({ disabled }) => ({
+  color: 'white',
+  fontSize: 14,
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  textDecoration: 'underline',
+  transition: 'opacity 0.2s',
+  opacity: disabled ? 0.5 : 1,
+  pointerEvents: disabled ? 'none' : 'auto',
+  '&:hover': {
+    opacity: disabled ? 0.5 : 0.8
+  }
+}))
+
+export {
+  OTP_MODAL_ROOT_CLASS,
+  otpModalContainerGlobalStyles,
+  StyledDialog,
+  Header,
+  BackButton,
+  BackIcon,
+  CloseButton,
+  Main,
+  Content,
+  EmailIconContainer,
+  EmailIcon,
+  Title,
+  Subtitle,
+  OtpContainer,
+  OtpInput,
+  VerifyingContainer,
+  VerifyingLoader,
+  VerifyingText,
+  ErrorMessage,
+  ResendText,
+  ResendLink,
+  ResendLinkError
+}

--- a/src/components/Pages/MobileAuthPage/MobileEmailLoginModal/MobileEmailLoginModal.tsx
+++ b/src/components/Pages/MobileAuthPage/MobileEmailLoginModal/MobileEmailLoginModal.tsx
@@ -1,0 +1,345 @@
+import { ChangeEvent, ClipboardEvent, KeyboardEvent, useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from '@dcl/hooks'
+import { GlobalStyles } from 'decentraland-ui2'
+import emailIconUrl from '../../../../assets/images/email.svg'
+import { TrackingEvents } from '../../../../modules/analytics/types'
+import { sendEmailOTP, verifyEmailOTPAndConnect } from '../../../../shared/thirdweb'
+import { trackEvent } from '../../../../shared/utils/analytics'
+import { handleError } from '../../../../shared/utils/errorHandler'
+import { sendTestAuthCode, verifyTestAuthCode } from '../testAuth'
+import { EmailLoginModalProps } from './MobileEmailLoginModal.types'
+import {
+  BackButton,
+  BackIcon,
+  CloseButton,
+  Content,
+  EmailIcon,
+  EmailIconContainer,
+  ErrorMessage,
+  Header,
+  Main,
+  OTP_MODAL_ROOT_CLASS,
+  OtpContainer,
+  OtpInput,
+  ResendLink,
+  ResendLinkError,
+  ResendText,
+  StyledDialog,
+  Subtitle,
+  Title,
+  VerifyingContainer,
+  VerifyingLoader,
+  VerifyingText,
+  otpModalContainerGlobalStyles
+} from './MobileEmailLoginModal.styled'
+
+const OTP_LENGTH = 6
+const RESEND_COOLDOWN_SECONDS = 90
+
+const formatCountdown = (seconds: number): string => {
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = seconds % 60
+  return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`
+}
+
+const getTranslatedApiError = (
+  errorMessage: string | undefined,
+  fallback: string,
+  networkError: string,
+  knownErrors?: [string, string][]
+): string => {
+  if (errorMessage === 'Failed to fetch' || errorMessage?.toLowerCase().includes('network')) {
+    return networkError
+  }
+  if (errorMessage && knownErrors) {
+    const lowerMsg = errorMessage.toLowerCase()
+    for (const [pattern, translated] of knownErrors) {
+      if (lowerMsg.includes(pattern.toLowerCase())) {
+        return translated
+      }
+    }
+  }
+  return errorMessage || fallback
+}
+
+export const MobileEmailLoginModal = (props: EmailLoginModalProps) => {
+  const { open, email, isTestAuth, onClose, onBack, onSuccess } = props
+  const { t } = useTranslation()
+
+  const [otp, setOtp] = useState<string[]>(Array(OTP_LENGTH).fill(''))
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [hasError, setHasError] = useState(false)
+  const [resendCooldown, setResendCooldown] = useState(() => (open ? RESEND_COOLDOWN_SECONDS : 0))
+
+  const otpInputRefs = useRef<(HTMLInputElement | null)[]>([])
+  // Use ref to always have access to current email in callbacks
+  const emailRef = useRef(email)
+  emailRef.current = email
+
+  // Reset state when modal opens
+  useEffect(() => {
+    if (open) {
+      setOtp(Array(OTP_LENGTH).fill(''))
+      setError(null)
+      setIsLoading(false)
+      setHasError(false)
+      setResendCooldown(RESEND_COOLDOWN_SECONDS)
+      // Focus first OTP input after a short delay
+      setTimeout(() => otpInputRefs.current[0]?.focus(), 100)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (resendCooldown <= 0) {
+      return
+    }
+
+    const timeoutId = setTimeout(() => {
+      setResendCooldown(prev => Math.max(prev - 1, 0))
+    }, 1000)
+
+    return () => clearTimeout(timeoutId)
+  }, [resendCooldown])
+
+  const handleOtpSubmit = useCallback(
+    async (otpCode?: string) => {
+      const code = otpCode || otp.join('')
+      const currentEmail = emailRef.current
+
+      if (code.length !== OTP_LENGTH) {
+        setError(t('email_login_modal.enter_complete_code'))
+        return
+      }
+
+      setIsLoading(true)
+      setError(null)
+      setHasError(false)
+
+      try {
+        let address: string
+
+        if (isTestAuth) {
+          const result = await verifyTestAuthCode(currentEmail, code)
+          address = result.address
+          onSuccess({ email: currentEmail, address, identity: result.identity })
+        } else {
+          address = await verifyEmailOTPAndConnect(currentEmail, code)
+          localStorage.setItem('dcl_thirdweb_user_email', currentEmail)
+          onSuccess({ email: currentEmail, address })
+        }
+
+        // Track OTP verification success
+        trackEvent(TrackingEvents.OTP_VERIFICATION_SUCCESS, { email: currentEmail })
+      } catch (e) {
+        const errorMessage = handleError(e, 'Error verifying OTP')
+        setError(
+          getTranslatedApiError(errorMessage, t('email_login_modal.invalid_or_expired'), t('email_login_modal.network_error'), [
+            ['failed to verify', t('email_login_modal.failed_verify')]
+          ])
+        )
+        setHasError(true)
+
+        // Track OTP verification failure
+        trackEvent(TrackingEvents.OTP_VERIFICATION_FAILURE, { email: currentEmail, error: errorMessage })
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [otp, isTestAuth, onSuccess, t]
+  )
+
+  const handleOtpChange = useCallback(
+    (index: number, value: string) => {
+      // Only allow digits
+      const digit = value.replace(/\D/g, '').slice(-1)
+
+      const newOtp = [...otp]
+      newOtp[index] = digit
+      setOtp(newOtp)
+      setError(null)
+      setHasError(false)
+
+      // Auto-focus next input
+      if (digit && index < OTP_LENGTH - 1) {
+        otpInputRefs.current[index + 1]?.focus()
+      }
+
+      // Auto-submit when all digits are entered
+      if (digit && index === OTP_LENGTH - 1) {
+        const completeOtp = newOtp.join('')
+        if (completeOtp.length === OTP_LENGTH) {
+          handleOtpSubmit(completeOtp)
+        }
+      }
+    },
+    [otp, handleOtpSubmit]
+  )
+
+  const handleOtpKeyDown = useCallback(
+    (index: number, e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Backspace' && !otp[index] && index > 0) {
+        otpInputRefs.current[index - 1]?.focus()
+      }
+    },
+    [otp]
+  )
+
+  // Handle paste - distribute digits across all inputs
+  const handleOtpPaste = useCallback(
+    (e: ClipboardEvent<HTMLInputElement>) => {
+      e.preventDefault()
+      const pastedData = e.clipboardData.getData('text').replace(/\D/g, '').slice(0, OTP_LENGTH)
+
+      if (pastedData.length > 0) {
+        const newOtp = Array(OTP_LENGTH).fill('')
+        for (let i = 0; i < pastedData.length; i++) {
+          newOtp[i] = pastedData[i]
+        }
+        setOtp(newOtp)
+        setError(null)
+        setHasError(false)
+
+        // Focus the next empty input or the last one
+        const nextEmptyIndex = pastedData.length < OTP_LENGTH ? pastedData.length : OTP_LENGTH - 1
+        otpInputRefs.current[nextEmptyIndex]?.focus()
+
+        // Auto-submit if all digits are pasted
+        if (pastedData.length === OTP_LENGTH) {
+          handleOtpSubmit(pastedData)
+        }
+      }
+    },
+    [handleOtpSubmit]
+  )
+
+  const handleResendOtp = useCallback(async () => {
+    if (isLoading || resendCooldown > 0) {
+      return
+    }
+
+    const currentEmail = emailRef.current
+    setOtp(Array(OTP_LENGTH).fill(''))
+    setError(null)
+    setHasError(false)
+    setIsLoading(true)
+
+    try {
+      if (isTestAuth) {
+        await sendTestAuthCode(currentEmail)
+      } else {
+        await sendEmailOTP(currentEmail)
+      }
+
+      // Track OTP resend
+      trackEvent(TrackingEvents.OTP_RESEND, { email: currentEmail })
+      setResendCooldown(RESEND_COOLDOWN_SECONDS)
+
+      // Focus first OTP input
+      setTimeout(() => otpInputRefs.current[0]?.focus(), 100)
+    } catch (e) {
+      const errorMessage = handleError(e, 'Error resending OTP')
+      setError(getTranslatedApiError(errorMessage, t('email_login_modal.failed_resend'), t('email_login_modal.network_error')))
+      setHasError(true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [isLoading, isTestAuth, resendCooldown, t])
+
+  const handleClose = useCallback(() => {
+    if (!isLoading) {
+      onClose()
+    }
+  }, [isLoading, onClose])
+
+  const handleBack = useCallback(() => {
+    if (!isLoading) {
+      onBack()
+    }
+  }, [isLoading, onBack])
+
+  const isResendDisabled = isLoading || resendCooldown > 0
+  const resendCountdown = resendCooldown > 0 ? ` (${formatCountdown(resendCooldown)})` : ''
+  const resendText = `${t('email_login_modal.resend_code')}${resendCountdown}`
+
+  const renderContent = () => {
+    return (
+      <Content>
+        <EmailIconContainer>
+          <EmailIcon src={emailIconUrl} alt="" />
+        </EmailIconContainer>
+        <Title>{t('email_login_modal.title')}</Title>
+        <Subtitle>
+          {t('email_login_modal.subtitle_prefix')}
+          <strong>{email}</strong>
+          {t('email_login_modal.subtitle_suffix')}
+        </Subtitle>
+
+        <OtpContainer hasError={hasError}>
+          {otp.map((digit, index) => (
+            <OtpInput
+              key={index}
+              data-testid={`otp-input-${index}`}
+              ref={el => {
+                otpInputRefs.current[index] = el
+              }}
+              type="text"
+              inputMode="numeric"
+              maxLength={1}
+              value={digit}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => handleOtpChange(index, e.target.value)}
+              onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => handleOtpKeyDown(index, e)}
+              onPaste={handleOtpPaste}
+              hasError={hasError}
+              disabled={isLoading}
+              autoComplete="one-time-code"
+            />
+          ))}
+        </OtpContainer>
+
+        {isLoading && !error && (
+          <VerifyingContainer>
+            <VerifyingLoader size={16} />
+            <VerifyingText>{t('email_login_modal.verifying')}</VerifyingText>
+          </VerifyingContainer>
+        )}
+
+        {error && (
+          <>
+            <ErrorMessage>{error}</ErrorMessage>
+            <ResendLinkError disabled={isResendDisabled} onClick={!isResendDisabled ? handleResendOtp : undefined}>
+              {resendText}
+            </ResendLinkError>
+          </>
+        )}
+
+        {!error && (
+          <ResendText>
+            {t('email_login_modal.didnt_get_email')}
+            <ResendLink disabled={isResendDisabled} onClick={!isResendDisabled ? handleResendOtp : undefined}>
+              {resendText}
+            </ResendLink>
+          </ResendText>
+        )}
+      </Content>
+    )
+  }
+
+  return (
+    <>
+      {/* Only inject when open so we don't affect other modals (e.g. Connection/Metamask modal) */}
+      {open && <GlobalStyles styles={otpModalContainerGlobalStyles} />}
+      <StyledDialog open={open} maxWidth="sm" fullWidth className={OTP_MODAL_ROOT_CLASS}>
+        <Header>
+          <BackButton onClick={handleBack} disabled={isLoading} data-testid="email-login-back-button">
+            <BackIcon>‹</BackIcon> {t('email_login_modal.back')}
+          </BackButton>
+          <CloseButton onClick={handleClose} disabled={isLoading} data-testid="email-login-close-button">
+            ×
+          </CloseButton>
+        </Header>
+        <Main>{renderContent()}</Main>
+      </StyledDialog>
+    </>
+  )
+}

--- a/src/components/Pages/MobileAuthPage/MobileEmailLoginModal/MobileEmailLoginModal.types.ts
+++ b/src/components/Pages/MobileAuthPage/MobileEmailLoginModal/MobileEmailLoginModal.types.ts
@@ -1,0 +1,16 @@
+type EmailLoginResult = {
+  email: string
+  address: string
+  identity?: import('@dcl/crypto').AuthIdentity
+}
+
+type EmailLoginModalProps = {
+  open: boolean
+  email: string
+  isTestAuth?: boolean
+  onClose: () => void
+  onBack: () => void
+  onSuccess: (result: EmailLoginResult) => void
+}
+
+export type { EmailLoginResult, EmailLoginModalProps }

--- a/src/components/Pages/MobileAuthPage/MobileEmailLoginModal/index.ts
+++ b/src/components/Pages/MobileAuthPage/MobileEmailLoginModal/index.ts
@@ -1,0 +1,2 @@
+export { MobileEmailLoginModal } from './MobileEmailLoginModal'
+export type { EmailLoginModalProps, EmailLoginResult } from './MobileEmailLoginModal.types'

--- a/src/components/Pages/MobileAuthPage/MobileProviderSelection.tsx
+++ b/src/components/Pages/MobileAuthPage/MobileProviderSelection.tsx
@@ -5,15 +5,35 @@ type Props = {
   onConnect: (type: ConnectionOptionType) => void
   loadingOption?: ConnectionOptionType
   connectionOptions: NonNullable<ConnectionProps['connectionOptions']>
+  onEmailSubmit?: (email: string) => void
+  onEmailChange?: () => void
+  isEmailLoading?: boolean
+  emailError?: string | null
 }
 
-export const MobileProviderSelection = ({ onConnect, loadingOption, connectionOptions }: Props) => {
+export const MobileProviderSelection = ({
+  onConnect,
+  loadingOption,
+  connectionOptions,
+  onEmailSubmit,
+  onEmailChange,
+  isEmailLoading,
+  emailError
+}: Props) => {
   return (
     <Main component="main">
       <Background />
       <Content>
         <MobileConnectionWrapper>
-          <Connection onConnect={onConnect} loadingOption={loadingOption} connectionOptions={connectionOptions} />
+          <Connection
+            onConnect={onConnect}
+            onEmailSubmit={onEmailSubmit}
+            onEmailChange={onEmailChange}
+            loadingOption={loadingOption}
+            connectionOptions={connectionOptions}
+            isEmailLoading={isEmailLoading}
+            emailError={emailError}
+          />
         </MobileConnectionWrapper>
       </Content>
     </Main>

--- a/src/components/Pages/MobileAuthPage/testAuth.ts
+++ b/src/components/Pages/MobileAuthPage/testAuth.ts
@@ -1,0 +1,63 @@
+import { AuthIdentity } from '@dcl/crypto'
+import { config } from '../../../modules/config'
+
+type TestAuthVerifyResult = {
+  identity: AuthIdentity
+  address: string
+}
+
+function isTestAuthEmail(email: string): boolean {
+  const testDomain = config.get('TEST_AUTH_EMAIL_DOMAIN')
+  if (!testDomain) return false
+  return email.endsWith(`@${testDomain}`)
+}
+
+async function sendTestAuthCode(email: string): Promise<boolean> {
+  const bffUrl = config.get('MOBILE_BFF_URL')
+  const response = await fetch(`${bffUrl}/test-auth/send-code`, {
+    method: 'POST',
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email })
+  })
+
+  if (response.status === 403) return false
+
+  if (!response.ok) {
+    const data = await response.json()
+    throw new Error(data.error || 'Failed to send test auth code')
+  }
+
+  return true
+}
+
+async function verifyTestAuthCode(email: string, code: string): Promise<TestAuthVerifyResult> {
+  const bffUrl = config.get('MOBILE_BFF_URL')
+  const response = await fetch(`${bffUrl}/test-auth/verify-code`, {
+    method: 'POST',
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, code })
+  })
+
+  if (!response.ok) {
+    let message = 'Failed to verify test auth code'
+    try {
+      const data = await response.json()
+      message = data.error || message
+    } catch {
+      // Non-JSON error body (e.g., gateway 502)
+    }
+    const error: Error & { skipReporting?: boolean } = new Error(message)
+    if (response.status === 401) {
+      error.skipReporting = true
+    }
+    throw error
+  }
+
+  const data = await response.json()
+  return data.data as TestAuthVerifyResult
+}
+
+export { isTestAuthEmail, sendTestAuthCode, verifyTestAuthCode }
+export type { TestAuthVerifyResult }

--- a/src/hooks/targetConfig.spec.ts
+++ b/src/hooks/targetConfig.spec.ts
@@ -76,70 +76,31 @@ describe('useTargetConfig', () => {
     })
   })
 
-  describe('when a targetConfigId is provided as androidSocial', () => {
+  describe('when on mobile, the targetConfigId override is ignored', () => {
     beforeEach(() => {
-      ;(useLocation as jest.Mock).mockReturnValue({ search: '?targetConfigId=androidSocial' })
-      ;(isMobile as jest.Mock).mockReturnValue(false)
+      ;(isMobile as jest.Mock).mockReturnValue(true)
     })
 
-    it('should return the androidSocial config', () => {
-      const { result } = renderHook(() => useTargetConfig())
-      const [config, targetConfigId] = result.current
-
-      expect(targetConfigId).toBe('androidSocial')
-      expect(config).toEqual(_targetConfigs.androidSocial)
-    })
-  })
-
-  describe('when a targetConfigId is provided as androidWeb3', () => {
-    beforeEach(() => {
-      ;(useLocation as jest.Mock).mockReturnValue({ search: '?targetConfigId=androidWeb3' })
-      ;(isMobile as jest.Mock).mockReturnValue(false)
-    })
-
-    it('should return the androidWeb3 config', () => {
-      const { result } = renderHook(() => useTargetConfig())
-      const [config, targetConfigId] = result.current
-
-      expect(targetConfigId).toBe('androidWeb3')
-      expect(config).toEqual(_targetConfigs.androidWeb3)
-    })
-  })
-
-  describe('when a targetConfigId is provided as default', () => {
-    beforeEach(() => {
+    it('should resolve to the android config when ?targetConfigId=default and not iOS', () => {
       ;(useLocation as jest.Mock).mockReturnValue({ search: '?targetConfigId=default' })
-      ;(isMobile as jest.Mock).mockReturnValue(true)
-    })
+      ;(isIos as jest.Mock).mockReturnValue(false)
 
-    it('should return the default config', () => {
-      const { result } = renderHook(() => useTargetConfig())
-      const [config] = result.current
-
-      // Default config now has EMAIL as primary, METAMASK as secondary
-      // On mobile, METAMASK is replaced with WALLET_CONNECT
-      expect(config.connectionOptions.primary).toBe(ConnectionOptionType.EMAIL)
-      expect(config.connectionOptions.secondary).toBe(ConnectionOptionType.WALLET_CONNECT)
-      expect(config.connectionOptions.extraOptions).not.toContain(ConnectionOptionType.METAMASK)
-    })
-  })
-
-  describe('when a targetConfigId is provided as alternative', () => {
-    beforeEach(() => {
-      ;(useLocation as jest.Mock).mockReturnValue({ search: '?targetConfigId=alternative' })
-      ;(isMobile as jest.Mock).mockReturnValue(true)
-    })
-
-    it('should return the alternative config', () => {
       const { result } = renderHook(() => useTargetConfig())
       const [config, targetConfigId] = result.current
 
-      expect(targetConfigId).toBe('alternative')
-      // Alternative config inherits from default, so it also has EMAIL as primary
-      // On mobile, METAMASK is replaced with WALLET_CONNECT
-      expect(config.connectionOptions.primary).toBe(ConnectionOptionType.EMAIL)
-      expect(config.connectionOptions.secondary).toBe(ConnectionOptionType.WALLET_CONNECT)
-      expect(config.connectionOptions.extraOptions).not.toContain(ConnectionOptionType.METAMASK)
+      expect(targetConfigId).toBe('android')
+      expect(config).toEqual(_targetConfigs.android)
+    })
+
+    it('should resolve to the ios config when ?targetConfigId=alternative and on iOS', () => {
+      ;(useLocation as jest.Mock).mockReturnValue({ search: '?targetConfigId=alternative' })
+      ;(isIos as jest.Mock).mockReturnValue(true)
+
+      const { result } = renderHook(() => useTargetConfig())
+      const [config, targetConfigId] = result.current
+
+      expect(targetConfigId).toBe('ios')
+      expect(config).toEqual(_targetConfigs.ios)
     })
   })
 
@@ -171,7 +132,7 @@ describe('useTargetConfig', () => {
 
       expect(targetConfigId).toBe('ios')
       expect(config.connectionOptions.primary).toBe(ConnectionOptionType.APPLE)
-      expect(config.connectionOptions.secondary).toBe(ConnectionOptionType.WALLET_CONNECT)
+      expect(config.connectionOptions.secondary).toBe(ConnectionOptionType.GOOGLE)
     })
   })
 
@@ -188,7 +149,7 @@ describe('useTargetConfig', () => {
 
       expect(targetConfigId).toBe('android')
       expect(config.connectionOptions.primary).toBe(ConnectionOptionType.GOOGLE)
-      expect(config.connectionOptions.secondary).toBe(ConnectionOptionType.WALLET_CONNECT)
+      expect(config.connectionOptions.secondary).toBe(ConnectionOptionType.APPLE)
     })
   })
 })

--- a/src/hooks/targetConfig.ts
+++ b/src/hooks/targetConfig.ts
@@ -3,7 +3,7 @@ import { ConnectionOptionType } from '../components/Connection'
 import { isIos, isMobile } from '../components/Pages/LoginPage/utils'
 import { extractRedirectToFromSearchParameters } from '../shared/locations'
 
-type TargetConfigId = 'default' | 'alternative' | 'ios' | 'android' | 'androidSocial' | 'androidWeb3'
+type TargetConfigId = 'default' | 'alternative' | 'ios' | 'android'
 
 type ConnectionOptions = {
   primary: ConnectionOptionType
@@ -60,65 +60,17 @@ const targetConfigs: Record<TargetConfigId, TargetConfig> = {
     ...defaultMobileConfig,
     connectionOptions: {
       primary: ConnectionOptionType.APPLE,
-      secondary: ConnectionOptionType.WALLET_CONNECT,
-      extraOptions: [
-        ConnectionOptionType.GOOGLE,
-        ConnectionOptionType.DISCORD,
-        ConnectionOptionType.X,
-        ConnectionOptionType.FORTMATIC,
-        ConnectionOptionType.COINBASE
-      ]
+      secondary: ConnectionOptionType.GOOGLE,
+      extraOptions: [ConnectionOptionType.WALLET_CONNECT]
     }
   },
   android: {
     ...defaultMobileConfig,
     connectionOptions: {
       primary: ConnectionOptionType.GOOGLE,
-      secondary: ConnectionOptionType.WALLET_CONNECT,
-      extraOptions: [
-        ConnectionOptionType.DISCORD,
-        ConnectionOptionType.APPLE,
-        ConnectionOptionType.X,
-        ConnectionOptionType.FORTMATIC,
-        ConnectionOptionType.COINBASE
-      ]
+      secondary: ConnectionOptionType.APPLE,
+      extraOptions: [ConnectionOptionType.METAMASK]
     }
-  },
-  androidSocial: {
-    ...defaultMobileConfig,
-    connectionOptions: {
-      primary: ConnectionOptionType.EMAIL,
-      secondary: ConnectionOptionType.GOOGLE,
-      extraOptions: [ConnectionOptionType.APPLE, ConnectionOptionType.DISCORD, ConnectionOptionType.X]
-    }
-  },
-  androidWeb3: {
-    ...defaultMobileConfig,
-    connectionOptions: {
-      primary: ConnectionOptionType.WALLET_CONNECT
-    }
-  }
-}
-
-const adjustWeb3OptionsForMobile = (config: TargetConfig): TargetConfig => {
-  let { primary, secondary, extraOptions } = config.connectionOptions
-
-  // Replace Metamask Extension for Wallet Connect on Mobile
-  if (primary === ConnectionOptionType.METAMASK) {
-    primary = ConnectionOptionType.WALLET_CONNECT
-    extraOptions = extraOptions?.filter(option => option !== ConnectionOptionType.WALLET_CONNECT)
-  }
-
-  if (secondary === ConnectionOptionType.METAMASK) {
-    secondary = ConnectionOptionType.WALLET_CONNECT
-    extraOptions = extraOptions?.filter(option => option !== ConnectionOptionType.WALLET_CONNECT)
-  }
-
-  extraOptions = extraOptions?.filter(option => option !== ConnectionOptionType.METAMASK)
-
-  return {
-    ...config,
-    connectionOptions: { primary, secondary, extraOptions }
   }
 }
 
@@ -126,6 +78,13 @@ const adjustWeb3OptionsForMobile = (config: TargetConfig): TargetConfig => {
 const _targetConfigs = targetConfigs
 
 const getTargetConfigId = (location: Location): TargetConfigId => {
+  // On mobile, always use the OS-specific config and ignore any explicit
+  // targetConfigId override. This guarantees mobile users only ever see
+  // mobile-friendly providers (no METAMASK extension, etc.).
+  if (isMobile()) {
+    return isIos() ? 'ios' : 'android'
+  }
+
   const search = new URLSearchParams(location.search)
   const targetConfigIdParam = search.get('targetConfigId') as TargetConfigId
   const redirectTo = extractRedirectToFromSearchParameters(search)
@@ -133,11 +92,6 @@ const getTargetConfigId = (location: Location): TargetConfigId => {
   // If explicit targetConfigId is provided, use it
   if (targetConfigIdParam in targetConfigs) {
     return targetConfigIdParam
-  }
-
-  // Auto-detect iOS/Android on mobile
-  if (isMobile()) {
-    return isIos() ? 'ios' : 'android'
   }
 
   // Check redirectTo URL for targetConfigId (desktop flow)
@@ -165,11 +119,7 @@ const getTargetConfigId = (location: Location): TargetConfigId => {
 const useTargetConfig = (): [TargetConfig, TargetConfigId] => {
   const location = useLocation()
   const targetConfigId = getTargetConfigId(location)
-  let config = targetConfigs[targetConfigId]
-  if (isMobile()) {
-    config = adjustWeb3OptionsForMobile(config)
-  }
-  return [config, targetConfigId]
+  return [targetConfigs[targetConfigId], targetConfigId]
 }
 
 export { _targetConfigs, useTargetConfig }

--- a/src/modules/config/env/dev.json
+++ b/src/modules/config/env/dev.json
@@ -15,5 +15,7 @@
   "META_TRANSACTION_SERVER_URL": "https://transactions-api.decentraland.zone",
   "PLACES_API_URL": "https://places.decentraland.zone",
   "PROFILE_CONSISTENCY_CHECK_TIMEOUT": "10000",
-  "EVENTS_NOTIFIER_URL": "https://events-notifier.decentraland.zone"
+  "EVENTS_NOTIFIER_URL": "https://events-notifier.decentraland.zone",
+  "MOBILE_BFF_URL": "http://localhost:3000",
+  "TEST_AUTH_EMAIL_DOMAIN": "dclregenesislabs.xyz"
 }

--- a/src/modules/config/env/prod.json
+++ b/src/modules/config/env/prod.json
@@ -15,5 +15,7 @@
   "META_TRANSACTION_SERVER_URL": "https://transactions-api.decentraland.org",
   "PLACES_API_URL": "https://places.decentraland.org",
   "PROFILE_CONSISTENCY_CHECK_TIMEOUT": "10000",
-  "EVENTS_NOTIFIER_URL": "https://events-notifier.decentraland.org"
+  "EVENTS_NOTIFIER_URL": "https://events-notifier.decentraland.org",
+  "MOBILE_BFF_URL": "https://mobile-bff.decentraland.org",
+  "TEST_AUTH_EMAIL_DOMAIN": "dclregenesislabs.xyz"
 }

--- a/src/modules/config/env/stg.json
+++ b/src/modules/config/env/stg.json
@@ -15,5 +15,7 @@
   "META_TRANSACTION_SERVER_URL": "https://transactions-api.decentraland.today",
   "PLACES_API_URL": "https://places.decentraland.today",
   "PROFILE_CONSISTENCY_CHECK_TIMEOUT": "10000",
-  "EVENTS_NOTIFIER_URL": "https://events-notifier.decentraland.zone"
+  "EVENTS_NOTIFIER_URL": "https://events-notifier.decentraland.zone",
+  "MOBILE_BFF_URL": "https://mobile-bff.decentraland.today",
+  "TEST_AUTH_EMAIL_DOMAIN": "dclregenesislabs.xyz"
 }


### PR DESCRIPTION
## Summary

- Brings the existing Thirdweb email OTP login to the mobile auth page (`/auth/mobile`) without modifying any desktop code
- Adds Apple App Store review support: emails matching a configurable test domain are routed to mobile-bff for code validation, with transparent fallback to Thirdweb if rejected
- Simplifies mobile target configs (iOS/Android always used on mobile, removed `adjustWeb3OptionsForMobile`)
- Improves mobile layout: centered content, responsive title, new background gradient
- Supports `?email=` URL param to pre-fill and auto-submit the email field

## What could break

- Mobile provider ordering changed: social logins (Apple/Google) are now primary/secondary, email in extras
- `androidSocial` and `androidWeb3` target config IDs removed — any deep links using `?targetConfigId=androidSocial` or `androidWeb3` will fall back to the default iOS/Android config
- `adjustWeb3OptionsForMobile` removed — mobile users with `?targetConfigId=default` now get iOS/Android config instead of the desktop default with MetaMask→WalletConnect swap

## How to test

**Email OTP (normal flow):**
1. Open `/auth/mobile` (or with mobile UA)
2. Enter a valid email → OTP modal opens
3. Enter the 6-digit code from your email → success screen with deep link

**Apple test auth:**
1. Configure `TEST_AUTH_EMAIL`, `TEST_AUTH_OTP_CODE`, `TEST_AUTH_PRIVATE_KEY` on mobile-bff
2. Configure `MOBILE_BFF_URL` and `TEST_AUTH_EMAIL_DOMAIN` in auth frontend config
3. Enter the exact test email → OTP modal opens (no real email sent)
4. Enter the fixed test code → success screen with deep link
5. Enter a different `@dclregenesislabs.xyz` email → silently falls back to Thirdweb

**Desktop regression:**
- Verify `/auth/login` email flow works unchanged
- `git diff -- src/components/Pages/LoginPage src/components/EmailLoginModal src/shared/thirdweb` should be empty