### PR TITLE
fix: avoid bare-spinner flash between auth callback and request page

### DIFF
--- a/src/components/Pages/RequestPage/Views/LoadingRequest.tsx
+++ b/src/components/Pages/RequestPage/Views/LoadingRequest.tsx
@@ -1,22 +1,3 @@
-import { CircularProgress } from 'decentraland-ui2'
-import { AnimatedBackground } from '../../../AnimatedBackground'
+import { VerifyingCredentialsView } from '../../../VerifyingCredentialsView'
 
-export const LoadingRequest = () => {
-  return (
-    <div>
-      <AnimatedBackground />
-      <div
-        style={{
-          position: 'absolute',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          height: '100%',
-          width: '100%'
-        }}
-      >
-        <CircularProgress size={60} />
-      </div>
-    </div>
-  )
-}
+export const LoadingRequest = () => <VerifyingCredentialsView />

--- a/src/components/VerifyingCredentialsView/VerifyingCredentialsView.spec.tsx
+++ b/src/components/VerifyingCredentialsView/VerifyingCredentialsView.spec.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react'
+import { VerifyingCredentialsView } from './VerifyingCredentialsView'
+
+jest.mock('@dcl/hooks', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+jest.mock('../AnimatedBackground', () => ({
+  AnimatedBackground: () => null
+}))
+
+jest.mock('decentraland-ui2', () => {
+  const actual = jest.requireActual('decentraland-ui2')
+  return {
+    ...actual,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    CircularProgress: () => <div data-testid="spinner" />,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    Logo: () => <div data-testid="logo" />
+  }
+})
+
+describe('when rendering the VerifyingCredentialsView', () => {
+  describe('and no messageKey is provided', () => {
+    it('should render the default validating_sign_in label, logo and spinner', () => {
+      const { getByTestId } = render(<VerifyingCredentialsView />)
+      expect(getByTestId('verifying-credentials-title')).toHaveTextContent('connection_layout.validating_sign_in')
+      expect(getByTestId('logo')).toBeInTheDocument()
+      expect(getByTestId('spinner')).toBeInTheDocument()
+    })
+  })
+
+  describe('and a custom messageKey is provided', () => {
+    it('should render the provided translation key as the label', () => {
+      const { getByTestId } = render(<VerifyingCredentialsView messageKey="some.custom.key" />)
+      expect(getByTestId('verifying-credentials-title')).toHaveTextContent('some.custom.key')
+    })
+  })
+})

--- a/src/components/VerifyingCredentialsView/VerifyingCredentialsView.styled.ts
+++ b/src/components/VerifyingCredentialsView/VerifyingCredentialsView.styled.ts
@@ -1,0 +1,19 @@
+import { Box, styled } from 'decentraland-ui2'
+
+const Container = styled(Box)({
+  display: 'flex',
+  height: '100vh',
+  width: '100vw',
+  position: 'relative'
+})
+
+const Wrapper = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  height: '100%',
+  width: '100%'
+})
+
+export { Container, Wrapper }

--- a/src/components/VerifyingCredentialsView/VerifyingCredentialsView.tsx
+++ b/src/components/VerifyingCredentialsView/VerifyingCredentialsView.tsx
@@ -1,0 +1,36 @@
+import { useTranslation } from '@dcl/hooks'
+import { CircularProgress } from 'decentraland-ui2'
+import { AnimatedBackground } from '../AnimatedBackground'
+import {
+  ConnectionContainer,
+  ConnectionTitle,
+  DecentralandLogo,
+  ProgressContainer
+} from '../ConnectionModal/ConnectionLayout.styled'
+import { Container, Wrapper } from './VerifyingCredentialsView.styled'
+
+type Props = {
+  /** Translation key for the label shown above the spinner. Defaults to the callback-page message for visual continuity. */
+  messageKey?: string
+}
+
+// Shared loading view used in transitional states (LoadingRequest, DefaultPage, etc.)
+// Mirrors the CallbackPage layout so the user perceives one continuous "verifying" phase
+// instead of a bare spinner flash between screens.
+export const VerifyingCredentialsView = ({ messageKey = 'connection_layout.validating_sign_in' }: Props) => {
+  const { t } = useTranslation()
+  return (
+    <Container>
+      <AnimatedBackground variant="absolute" />
+      <Wrapper>
+        <ConnectionContainer>
+          <DecentralandLogo size="huge" />
+          <ConnectionTitle data-testid="verifying-credentials-title">{t(messageKey)}</ConnectionTitle>
+          <ProgressContainer>
+            <CircularProgress color="inherit" />
+          </ProgressContainer>
+        </ConnectionContainer>
+      </Wrapper>
+    </Container>
+  )
+}

--- a/src/components/VerifyingCredentialsView/index.ts
+++ b/src/components/VerifyingCredentialsView/index.ts
@@ -1,0 +1,1 @@
+export { VerifyingCredentialsView } from './VerifyingCredentialsView'


### PR DESCRIPTION
# fix: avoid bare-spinner flash between auth callback and request page

## Summary

During Social (Magic) login with an Explorer-initiated flow, the user was seeing a brief "spinner only" flash between the callback screen and the final success page. Sequence was:

1. `/auth/callback` → ConnectionLayout with "Just a moment, we're verifying your login credentials…" + spinner ✅
2. `redirect()` fires → browser navigates to `/auth/requests/:id`
3. `RequestPage` mounts in `View.LOADING_REQUEST` → renders `<LoadingRequest />` → **bare spinner, no label, no logo** 💥
4. Request loads → success page (Sign-In complete) ✅

Step 3 is the flash. The root cause is that `LoadingRequest.tsx` was implemented as a bare `<CircularProgress />` with no visual continuity with the preceding callback screen, so the user briefly loses all context.

## What this PR changes

- **New shared component** `src/components/VerifyingCredentialsView` — wraps logo + "validating_sign_in" translation + spinner using the same styled components that `ConnectionLayout` already uses (no duplication of styles). Exposes an optional `messageKey` prop for future reuse with a different label.
- **`LoadingRequest.tsx`** now renders `<VerifyingCredentialsView />` instead of a bare spinner. The view the user sees during the initial RequestPage load is now visually identical to what CallbackPage was showing, so the transition feels like one continuous "verifying" phase.
- `CallbackPage` and `ConnectionLayout` are untouched — they already render the correct UI and support their own error states.
- `DefaultPage` (the wildcard `*` fallback) is intentionally left as-is. It's not part of the social login flow and it isn't "verifying credentials", so reusing that label there would be misleading.

Total delta: 1 modified file + 4 new files (component, styled, spec, index).

## Test plan

- [x] `src/components/VerifyingCredentialsView/VerifyingCredentialsView.spec.tsx` — renders default and custom message keys with logo + spinner.
- [x] Existing `RequestPage.spec.tsx` and `DefaultPage.spec.tsx` continue to pass unchanged.
- [x] Full jest suite: 514/514 pass.
- [x] `npx tsc --noEmit` clean.

### Manual scenarios to verify

**Primary fix — Social login + Explorer**

1. Clean cache: `rm -rf ~/Library/Application\ Support/Decentraland/Explorer`.
2. Start the Explorer and trigger the auth flow (Explorer opens the browser at `/auth/requests/:id`).
3. Click Google / Discord / Apple → complete OAuth.
4. Expected: between `/auth/callback` and the success page, the logo + "Just a moment, we're verifying your login credentials…" + spinner stays visible continuously. No bare-spinner flash.

**RequestPage cold-loaded**

1. With an active session, paste `http://localhost:5174/auth/requests/<any-id>` directly.
2. Expected: during the initial request fetch, the logo + label + spinner appear (not a bare spinner).

**Regression — CallbackPage error path**

1. Start a Social login, then cancel on the OAuth provider.
2. Expected: CallbackPage correctly shows its error state with retry button (unchanged from today).
