### PR TITLE
fix: hide email input on account creation when sign-in already collected it

### DIFF
--- a/src/components/Pages/QuickSetupPage/QuickSetupPage.spec.tsx
+++ b/src/components/Pages/QuickSetupPage/QuickSetupPage.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { subscribeToNewsletter } from '../SetupPage/utils'
 import { QuickSetupPage } from './QuickSetupPage'
 
 // --- Mocks ---
@@ -79,6 +80,7 @@ jest.mock('@dcl/hooks', () => ({
         'quick_setup.email_label': 'Email',
         'quick_setup.email_placeholder': 'Enter your email',
         'quick_setup.email_helper': 'Subscribe to newsletter',
+        'quick_setup.newsletter_subscribe': 'Subscribe to newsletter for updates on features, events, contests, and more.',
         'quick_setup.terms_of_use': 'Terms of Use',
         'quick_setup.privacy_policy': 'Privacy Policy',
         'quick_setup.lets_go': "LET'S GO",
@@ -276,6 +278,64 @@ describe('QuickSetupPage', () => {
       expect(getByText('0/15')).toBeInTheDocument()
       await user.type(getByPlaceholderText('Enter your username'), 'Hello')
       expect(getByText('5/15')).toBeInTheDocument()
+    })
+  })
+
+  describe('when the user signed in with a flow that already collected the email (Google / email + OTP)', () => {
+    const inheritedEmail = 'inherited@example.com'
+
+    beforeEach(() => {
+      ;(subscribeToNewsletter as jest.Mock).mockClear()
+      localStorage.setItem('dcl_thirdweb_user_email', inheritedEmail)
+    })
+
+    afterEach(() => {
+      localStorage.removeItem('dcl_thirdweb_user_email')
+      localStorage.removeItem('dcl_magic_user_email')
+    })
+
+    it('should not render the email input field', () => {
+      const { queryByPlaceholderText } = render(<QuickSetupPage />)
+      expect(queryByPlaceholderText('Enter your email')).not.toBeInTheDocument()
+    })
+
+    it('should render the newsletter subscription checkbox', () => {
+      const { getByText } = render(<QuickSetupPage />)
+      expect(getByText('Subscribe to newsletter for updates on features, events, contests, and more.')).toBeInTheDocument()
+    })
+
+    it('should subscribe with the inherited email when the newsletter checkbox is checked', async () => {
+      const user = userEvent.setup()
+      const { getByText, getByPlaceholderText, getAllByRole } = render(<QuickSetupPage />)
+
+      await user.type(getByPlaceholderText('Enter your username'), 'TestUser')
+      // Checkboxes order: [newsletter, terms]
+      const checkboxes = getAllByRole('checkbox')
+      await user.click(checkboxes[0])
+      await user.click(checkboxes[1])
+
+      await user.click(getByText("LET'S GO").closest('button')!)
+
+      await waitFor(() => {
+        expect(subscribeToNewsletter).toHaveBeenCalledWith(inheritedEmail)
+      })
+    })
+
+    it('should not subscribe when the newsletter checkbox is left unchecked', async () => {
+      const user = userEvent.setup()
+      const { getByText, getByPlaceholderText, getAllByRole } = render(<QuickSetupPage />)
+
+      await user.type(getByPlaceholderText('Enter your username'), 'TestUser')
+      // Only check the terms checkbox (index 1)
+      const checkboxes = getAllByRole('checkbox')
+      await user.click(checkboxes[1])
+
+      await user.click(getByText("LET'S GO").closest('button')!)
+
+      await waitFor(() => {
+        expect(getByText('Your account is Ready!')).toBeInTheDocument()
+      })
+      expect(subscribeToNewsletter).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/components/Pages/QuickSetupPage/QuickSetupPage.spec.tsx
+++ b/src/components/Pages/QuickSetupPage/QuickSetupPage.spec.tsx
@@ -338,4 +338,36 @@ describe('QuickSetupPage', () => {
       expect(subscribeToNewsletter).not.toHaveBeenCalled()
     })
   })
+
+  describe('when only the Magic-issued email is stored in localStorage', () => {
+    const magicEmail = 'magic@example.com'
+
+    beforeEach(() => {
+      ;(subscribeToNewsletter as jest.Mock).mockClear()
+      localStorage.removeItem('dcl_thirdweb_user_email')
+      localStorage.setItem('dcl_magic_user_email', magicEmail)
+    })
+
+    afterEach(() => {
+      localStorage.removeItem('dcl_magic_user_email')
+    })
+
+    it('should hide the email input and use the Magic email when subscribing', async () => {
+      const user = userEvent.setup()
+      const { getByText, getByPlaceholderText, queryByPlaceholderText, getAllByRole } = render(<QuickSetupPage />)
+
+      expect(queryByPlaceholderText('Enter your email')).not.toBeInTheDocument()
+
+      await user.type(getByPlaceholderText('Enter your username'), 'TestUser')
+      const checkboxes = getAllByRole('checkbox')
+      await user.click(checkboxes[0])
+      await user.click(checkboxes[1])
+
+      await user.click(getByText("LET'S GO").closest('button')!)
+
+      await waitFor(() => {
+        expect(subscribeToNewsletter).toHaveBeenCalledWith(magicEmail)
+      })
+    })
+  })
 })

--- a/src/components/Pages/QuickSetupPage/QuickSetupPage.tsx
+++ b/src/components/Pages/QuickSetupPage/QuickSetupPage.tsx
@@ -131,7 +131,12 @@ export const QuickSetupPage = () => {
           disabledCatalysts
         })
 
-        const newsletterEmail = inheritedEmail ? (subscribeNewsletter ? inheritedEmail : '') : email.trim()
+        let newsletterEmail = ''
+        if (inheritedEmail && subscribeNewsletter) {
+          newsletterEmail = inheritedEmail
+        } else if (!inheritedEmail) {
+          newsletterEmail = email.trim()
+        }
         if (newsletterEmail) {
           try {
             await subscribeToNewsletter(newsletterEmail)

--- a/src/components/Pages/QuickSetupPage/QuickSetupPage.tsx
+++ b/src/components/Pages/QuickSetupPage/QuickSetupPage.tsx
@@ -7,6 +7,7 @@ import randomizeIconSvg from '../../../assets/images/randomize-icon.svg'
 import { useAfterLoginRedirection } from '../../../hooks/redirection'
 import { useDisabledCatalysts } from '../../../hooks/useDisabledCatalysts'
 import { useCurrentConnectionData } from '../../../shared/connection'
+import { getStoredEmail } from '../../../shared/onboarding/getStoredEmail'
 import { trackCheckpoint } from '../../../shared/onboarding/trackCheckpoint'
 import { handleError } from '../../../shared/utils/errorHandler'
 import { AnimatedBackground } from '../../AnimatedBackground'
@@ -66,8 +67,10 @@ export const QuickSetupPage = () => {
   const { account, identity } = useCurrentConnectionData()
   const isMobile = useMobileMediaQuery()
 
+  const [inheritedEmail] = useState<string | null>(() => getStoredEmail())
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
+  const [subscribeNewsletter, setSubscribeNewsletter] = useState(false)
   const [agree, setAgree] = useState(false)
   const [deploying, setDeploying] = useState(false)
   const [deployError, setDeployError] = useState<string | null>(null)
@@ -128,9 +131,10 @@ export const QuickSetupPage = () => {
           disabledCatalysts
         })
 
-        if (email.trim()) {
+        const newsletterEmail = inheritedEmail ? (subscribeNewsletter ? inheritedEmail : '') : email.trim()
+        if (newsletterEmail) {
           try {
-            await subscribeToNewsletter(email.trim())
+            await subscribeToNewsletter(newsletterEmail)
           } catch (err) {
             handleError(err, 'Error subscribing to newsletter', { skipTracking: true })
           }
@@ -157,7 +161,7 @@ export const QuickSetupPage = () => {
         setDeploying(false)
       }
     },
-    [canSubmit, account, identity, profile, name, email, disabledCatalysts]
+    [canSubmit, account, identity, profile, name, email, inheritedEmail, subscribeNewsletter, disabledCatalysts]
   )
 
   if (showCelebration) {
@@ -204,15 +208,26 @@ export const QuickSetupPage = () => {
               {name.length}/{MAX_NAME_LENGTH}
             </CharCount>
 
-            <InputLabel>{t('quick_setup.email_label')}</InputLabel>
-            <UsernameInput
-              placeholder={t('quick_setup.email_placeholder')}
-              value={email}
-              onChange={e => setEmail(e.target.value)}
-              type="email"
-              fullWidth
-            />
-            <EmailHelperText>{t('quick_setup.email_helper')}</EmailHelperText>
+            {!inheritedEmail && (
+              <>
+                <InputLabel>{t('quick_setup.email_label')}</InputLabel>
+                <UsernameInput
+                  placeholder={t('quick_setup.email_placeholder')}
+                  value={email}
+                  onChange={e => setEmail(e.target.value)}
+                  type="email"
+                  fullWidth
+                />
+                <EmailHelperText>{t('quick_setup.email_helper')}</EmailHelperText>
+              </>
+            )}
+
+            {inheritedEmail && (
+              <CheckboxRow
+                control={<CheckboxInput checked={subscribeNewsletter} onChange={(_, checked) => setSubscribeNewsletter(checked)} />}
+                label={t('quick_setup.newsletter_subscribe')}
+              />
+            )}
 
             <CheckboxRow
               control={<CheckboxInput checked={agree} onChange={(_, checked) => setAgree(checked)} />}

--- a/src/modules/translations/en.json
+++ b/src/modules/translations/en.json
@@ -255,6 +255,7 @@
     "email_label": "Email",
     "email_placeholder": "Enter your email",
     "email_helper": "Subscribe to Decentraland's newsletter for updates on features, events, contests, and more.",
+    "newsletter_subscribe": "Subscribe to newsletter for updates on features, events, contests, and more.",
     "agree_tos": "I agree with Decentraland's {termsLink} and {privacyLink}.*",
     "agree_prefix": "I agree with Decentraland's",
     "agree_connector": "and",

--- a/src/modules/translations/es.json
+++ b/src/modules/translations/es.json
@@ -263,6 +263,7 @@
     "email_label": "Email",
     "email_placeholder": "Ingresa tu correo electrónico",
     "email_helper": "Suscríbete al boletín de Decentraland para recibir actualizaciones sobre funciones, eventos, concursos y más.",
+    "newsletter_subscribe": "Suscríbete al boletín para recibir actualizaciones sobre funciones, eventos, concursos y más.",
     "agree_tos": "Estoy de acuerdo con los {termsLink} y la {privacyLink} de Decentraland.*",
     "agree_prefix": "Estoy de acuerdo con los",
     "agree_connector": "y la",

--- a/src/modules/translations/fr.json
+++ b/src/modules/translations/fr.json
@@ -263,6 +263,7 @@
     "email_label": "Email",
     "email_placeholder": "Entrez votre e-mail",
     "email_helper": "Abonnez-vous à la newsletter de Decentraland pour des mises à jour sur les fonctionnalités, événements, concours et plus encore.",
+    "newsletter_subscribe": "Abonnez-vous à la newsletter pour des mises à jour sur les fonctionnalités, événements, concours et plus encore.",
     "agree_tos": "J'accepte les {termsLink} et la {privacyLink} de Decentraland.*",
     "agree_prefix": "J'accepte les",
     "agree_connector": "et la",

--- a/src/modules/translations/it.json
+++ b/src/modules/translations/it.json
@@ -263,6 +263,7 @@
     "email_label": "Email",
     "email_placeholder": "Inserisci la tua e-mail",
     "email_helper": "Iscriviti alla newsletter di Decentraland per aggiornamenti su funzionalità, eventi, concorsi e altro ancora.",
+    "newsletter_subscribe": "Iscriviti alla newsletter per aggiornamenti su funzionalità, eventi, concorsi e altro ancora.",
     "agree_tos": "Accetto i {termsLink} e la {privacyLink} di Decentraland.*",
     "agree_prefix": "Accetto i",
     "agree_connector": "e la",

--- a/src/modules/translations/zh.json
+++ b/src/modules/translations/zh.json
@@ -263,6 +263,7 @@
     "email_label": "Email",
     "email_placeholder": "输入您的电子邮件",
     "email_helper": "订阅 Decentraland 通讯，获取功能、活动、比赛等更新信息。",
+    "newsletter_subscribe": "订阅通讯，获取功能、活动、比赛等更新信息。",
     "agree_tos": "我同意 Decentraland 的{termsLink}和{privacyLink}。*",
     "agree_prefix": "我同意 Decentraland 的",
     "agree_connector": "和",


### PR DESCRIPTION
Closes #390

When a user signs up with Google or email + OTP the email is already captured during sign-in, so the account-creation screen no longer renders the email input. Instead, an optional newsletter checkbox is shown; if checked, the previously stored email is subscribed on submit. Wallet flows keep the original email field unchanged.

## Test plan
- [ ] `npm test -- --testPathPattern='QuickSetupPage'`
- [ ] Sign in with Google and verify the account-creation screen shows the newsletter checkbox instead of the email input
- [ ] Sign in with email + OTP and verify the same
- [ ] Sign in with a wallet and verify the email input remains