### PR TITLE
fix: restore walletconnect on android login options

### DIFF
--- a/src/hooks/targetConfig.spec.ts
+++ b/src/hooks/targetConfig.spec.ts
@@ -151,5 +151,19 @@ describe('useTargetConfig', () => {
       expect(config.connectionOptions.primary).toBe(ConnectionOptionType.GOOGLE)
       expect(config.connectionOptions.secondary).toBe(ConnectionOptionType.APPLE)
     })
+
+    it('should include WALLET_CONNECT in extraOptions', () => {
+      const { result } = renderHook(() => useTargetConfig())
+      const [config] = result.current
+
+      expect(config.connectionOptions.extraOptions).toContain(ConnectionOptionType.WALLET_CONNECT)
+    })
+
+    it('should include METAMASK in extraOptions', () => {
+      const { result } = renderHook(() => useTargetConfig())
+      const [config] = result.current
+
+      expect(config.connectionOptions.extraOptions).toContain(ConnectionOptionType.METAMASK)
+    })
   })
 })

--- a/src/hooks/targetConfig.ts
+++ b/src/hooks/targetConfig.ts
@@ -69,7 +69,11 @@ const targetConfigs: Record<TargetConfigId, TargetConfig> = {
     connectionOptions: {
       primary: ConnectionOptionType.GOOGLE,
       secondary: ConnectionOptionType.APPLE,
-      extraOptions: [ConnectionOptionType.METAMASK]
+      // Include both wallet options for parity with iOS: MetaMask covers the
+      // DApp Browser path, WalletConnect covers every other mobile wallet
+      // (Trust, Rainbow, Coinbase, etc.). Without WalletConnect, Android
+      // users in Samsung Internet / Chrome only see a disabled MetaMask.
+      extraOptions: [ConnectionOptionType.METAMASK, ConnectionOptionType.WALLET_CONNECT]
     }
   }
 }


### PR DESCRIPTION
## Context

A user on Samsung Internet (Android) reported the login page shows only Google, Apple, and a disabled MetaMask button — no WalletConnect. That cuts off every Android user without the MetaMask DApp Browser from connecting a self-custody wallet (Trust, Rainbow, Coinbase Wallet, etc.) — they're left with social logins only.

## Root cause

`src/hooks/targetConfig.ts` has hardcoded mobile configs per OS. The Android branch was missing `WALLET_CONNECT` from its `extraOptions` while iOS still has it.

Git history shows the asymmetry was introduced by PR #375 (Apr 2026, *"feat: add Thirdweb email OTP and Apple test auth to mobile flow"*) during a "simplified targetConfig" refactor that also deleted the `adjustWeb3OptionsForMobile` helper that previously auto-swapped MetaMask→WalletConnect on mobile. Pre-#375 Android had `secondary: WALLET_CONNECT`. Post-#375 Android has `extraOptions: [METAMASK]` only. The PR description does not mention or justify the iOS/Android wallet asymmetry — it reads as collateral fallout of the refactor rather than a deliberate product call.

## Changes

- `src/hooks/targetConfig.ts`: Android `extraOptions` now contains both `METAMASK` (preserves the DApp Browser path) and `WALLET_CONNECT` (covers every WalletConnect-compatible mobile wallet via deep link).
- `src/hooks/targetConfig.spec.ts`: two regression tests asserting both values are present in the Android extras.

## Test plan

- [x] `npx jest src/hooks/targetConfig.spec.ts` — 11 / 11 passing.
- [x] `npx eslint -c .eslintrc.cjs src/hooks/targetConfig.ts src/hooks/targetConfig.spec.ts` — clean.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx prettier --check src/hooks/targetConfig.ts src/hooks/targetConfig.spec.ts` — clean.
- [ ] Post-deploy on Samsung Internet (Android): open `/auth/login`, expand "More options", confirm WalletConnect appears next to MetaMask, tap it, confirm the WalletConnect modal opens.

## Why now

The Android WalletConnect path uses the WC v2 connector that's already shipped — no new SDK, no bundle size impact. `fromConnectionOptionToProviderType` already maps `WALLET_CONNECT` to `ProviderType.WALLET_CONNECT_V2`, and `connectToProvider` already clears stale WC/AppKit storage before connecting. This change is purely re-enabling a code path that exists.