### PR TITLE
fix: avatar setup wearable preview iframe scrollbars

### DIFF
--- a/src/components/Pages/AvatarSetupPage/AvatarSetupPage.styled.ts
+++ b/src/components/Pages/AvatarSetupPage/AvatarSetupPage.styled.ts
@@ -272,7 +272,13 @@ const PreloadedWearableContainer = styled(Box, {
   pointerEvents: isVisible ? 'auto' : 'none',
   zIndex: isVisible ? 1000 : 0,
   transition: 'opacity 0.3s ease-in-out',
-  visibility: 'visible'
+  visibility: 'visible',
+  // The WearablePreview iframe defaults to display:inline, which adds a
+  // baseline descender gap and overflows the 100vh viewport by a few pixels,
+  // surfacing as scrollbars next to the avatar.
+  ['& iframe']: {
+    display: 'block'
+  }
 }))
 
 const ErrorLabel = styled(Typography)(({ theme }) => ({


### PR DESCRIPTION
The `WearablePreview` iframe in `PreloadedWearableContainer` defaults to `display: inline`, which adds a ~6px baseline-descender gap below the iframe. With the iframe sized at `height: 100%` over a `100vh` container, that gap pushes the container's `scrollHeight` past its `clientHeight`, surfacing as scrollbars next to and below the avatar during the new-user avatar setup step.

Forcing `display: block` on the iframe collapses the gap and removes the scrollbars.

Reproduced in Chrome: container `scrollHeight` 673 → 667 after applying the fix.

Closes #385

## Test plan

- [ ] Sign in with Google as a new user, reach the avatar setup, click "Customize My Avatar" and confirm no scrollbars appear around the avatar preview.