### PR TITLE
fix: pin oddish-action to pre-OIDC SHA for classic token auth

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -10,8 +10,6 @@ on:
 
 jobs:
   build-release:
-    permissions:
-      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
@@ -21,7 +19,14 @@ jobs:
           node-version: 24.x
           cache: 'npm'
       - name: Set package.json version
-        uses: decentraland/oddish-action@master
+        # Pinned to the last oddish-action commit BEFORE the Trusted Publishing
+        # (OIDC) patch was merged. This workflow authenticates to npm via
+        # `NODE_AUTH_TOKEN` (classic token), so we want oddish to keep writing
+        # `_authToken=${NODE_AUTH_TOKEN}` to `.npmrc` unconditionally. The
+        # post-OIDC oddish would otherwise try to skip that write when an OIDC
+        # token request URL is present, breaking classic auth.
+        # Bump only after confirming compatibility with the classic-token flow.
+        uses: decentraland/oddish-action@9f0ba286ebfc06407aaba65b16645247a74e2e1c # pre-OIDC, node16 runtime
         with:
           deterministic-snapshot: true
           only-update-versions: true
@@ -35,7 +40,8 @@ jobs:
           NODE_PATH: 'src'
           NODE_OPTIONS: '--max-old-space-size=6144'
       - name: Publish
-        uses: decentraland/oddish-action@master
+        # See note above on the oddish-action pin.
+        uses: decentraland/oddish-action@9f0ba286ebfc06407aaba65b16645247a74e2e1c # pre-OIDC, node16 runtime
         with:
           cwd: './dist'
           deterministic-snapshot: true
@@ -44,6 +50,9 @@ jobs:
           gitlab-token: ${{ secrets.GITLAB_CDN_DEPLOYER_TOKEN }}
           gitlab-pipeline-url: ${{ secrets.GITLAB_CDN_DEPLOYER_URL }}
         env:
+          # Requires a rotated NPM_TOKEN with "Bypass 2FA" enabled — without that,
+          # this step fails with `EOTP` because the npm account requires OTP on
+          # writes. Trusted Publishing (OIDC) is the long-term replacement.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create Sentry release
         if: github.event_name == 'release' && github.event.action == 'created'


### PR DESCRIPTION
## Why

The post-OIDC version of `decentraland/oddish-action` (master @ `0074f2d`) detects `ACTIONS_ID_TOKEN_REQUEST_URL` and, when present without `NODE_AUTH_TOKEN`, skips writing `_authToken` to `.npmrc` so npm can do the OIDC handshake.

But the goal here is the opposite: we want to keep classic-token auth as the stopgap and **rotate `NPM_TOKEN` to a fresh granular token with "Bypass 2FA" enabled**, instead of moving auth-site to Trusted Publishers (which requires npmjs.com-side configuration per package).

Pinning oddish to the last pre-OIDC commit guarantees `_authToken=${NODE_AUTH_TOKEN}` keeps getting written, and the rotated token is used as-is.

## Changes

- Both `oddish-action@master` references → pinned to `9f0ba286ebfc06407aaba65b16645247a74e2e1c`
  - That's the merge of decentraland/oddish-action#9 (revert back to node16 runtime)
  - It's the last commit on master BEFORE PR #10 added OIDC support
  - Bonus: also pre-PR #4, so we sidestep the node24 toolcache issues we saw on other repos.
- Removed `permissions: id-token: write` from the job. We're not using OIDC, so granting that capability is unnecessary surface area.
- Inline comments documenting the pin rationale and the token rotation prerequisite.

## ⚠️ Required action BEFORE merging

The `NPM_TOKEN` secret in this repo must be rotated to a fresh **Granular Access Token** with **"Bypass 2FA"** enabled, scoped to `@dcl/auth-site` (read + write).

If the current `NPM_TOKEN` is one of the tokens invalidated by [@npmjs's Mini Shai Hulud response](https://x.com/npmjs/status/2056960835030016286), the publish step will fail with `EOTP` (current state). After rotation, the publish should succeed.

Steps for whoever has maintainer access to `@dcl/auth-site` on npmjs.com:

1. https://www.npmjs.com/settings/decentralandbot/tokens (or whichever bot publishes)
2. **Generate New Token** → Granular Access Token
3. **Bypass 2FA**: ✅ tick
4. **Permissions**: Read and write on `@dcl/auth-site` (or scope `@dcl`)
5. Copy the token
6. GitHub: `decentraland/auth` → Settings → Secrets and variables → Actions → `NPM_TOKEN` → Update

## Tradeoff vs Trusted Publishing

This is a stopgap. The Trusted Publishing migration (like sites/marketplace) is the long-term fix because it eliminates the rotatable-token attack surface entirely. But that requires per-package config on npmjs.com for each `@dcl/*-site` package, which is more coordination than rotating one token.

We can revisit and migrate auth to Trusted Publishing later — bump oddish back to the latest pinned SHA, re-add `id-token: write`, drop `NODE_AUTH_TOKEN` env, and configure the Trusted Publisher on npmjs.com.

## Test plan

- [ ] Rotate `NPM_TOKEN` secret with a fresh Bypass-2FA token
- [ ] Merge this PR
- [ ] Verify the next push to `main` triggers `build-release.yaml` and publishes `@dcl/auth-site@x.y.z` successfully (no `EOTP`, no `ENEEDAUTH`)