### PR TITLE
fix: always rotate SSO ephemeral on sign-in

### DIFF
--- a/src/components/Pages/MobileAuthPage/identityUtils.spec.ts
+++ b/src/components/Pages/MobileAuthPage/identityUtils.spec.ts
@@ -1,0 +1,117 @@
+import { createWalletClient } from 'viem'
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+import { AuthIdentity, Authenticator } from '@dcl/crypto'
+import { localStorageStoreIdentity } from '@dcl/single-sign-on-client'
+import { Provider } from 'decentraland-connect'
+import { getIdentitySignature } from './identityUtils'
+
+jest.mock('@dcl/single-sign-on-client')
+jest.mock('@dcl/crypto')
+jest.mock('viem/accounts')
+jest.mock('viem', () => ({
+  createWalletClient: jest.fn(),
+  custom: jest.fn()
+}))
+jest.mock('viem/chains', () => ({
+  mainnet: {}
+}))
+
+const mockLocalStorageStoreIdentity = localStorageStoreIdentity as jest.MockedFunction<typeof localStorageStoreIdentity>
+const mockGeneratePrivateKey = generatePrivateKey as jest.MockedFunction<typeof generatePrivateKey>
+const mockPrivateKeyToAccount = privateKeyToAccount as jest.MockedFunction<typeof privateKeyToAccount>
+const mockCreateWalletClient = createWalletClient as jest.MockedFunction<typeof createWalletClient>
+const mockAuthenticator = Authenticator as jest.Mocked<typeof Authenticator>
+
+const VALID_PRIVATE_KEY = '0x' + 'ab'.repeat(32)
+const VALID_PUBLIC_KEY = '0x' + 'cd'.repeat(65)
+const VALID_ADDRESS = '0x' + 'ef'.repeat(20)
+
+// Mobile flow uses a 3-month ephemeral expiration vs 1 month on desktop.
+// Asserting this catches drift between identity.ts and identityUtils.ts if either
+// is changed without updating the other.
+const MOBILE_EPHEMERAL_MINUTES = 60 * 24 * 30 * 3
+
+function createMockIdentity(overrides?: { privateKey?: string; publicKey?: string; address?: string }): AuthIdentity {
+  return {
+    ephemeralIdentity: {
+      privateKey: overrides?.privateKey ?? VALID_PRIVATE_KEY,
+      publicKey: overrides?.publicKey ?? VALID_PUBLIC_KEY,
+      address: overrides?.address ?? VALID_ADDRESS
+    },
+    expiration: new Date(Date.now() + 1000 * 60 * 60),
+    authChain: []
+  } as unknown as AuthIdentity
+}
+
+function setupGenerateIdentityMocks(resultIdentity: AuthIdentity) {
+  mockGeneratePrivateKey.mockReturnValue(VALID_PRIVATE_KEY as `0x${string}`)
+  mockPrivateKeyToAccount.mockReturnValue({
+    address: VALID_ADDRESS as `0x${string}`,
+    publicKey: VALID_PUBLIC_KEY as `0x${string}`
+  } as ReturnType<typeof privateKeyToAccount>)
+  mockAuthenticator.initializeAuthChain.mockResolvedValue(resultIdentity)
+  mockCreateWalletClient.mockReturnValue({
+    getAddresses: jest.fn().mockResolvedValue([VALID_ADDRESS]),
+    signMessage: jest.fn().mockResolvedValue('0xsignature')
+  } as unknown as ReturnType<typeof createWalletClient>)
+}
+
+describe('getIdentitySignature (mobile)', () => {
+  const address = '0x1234567890abcdef1234567890abcdef12345678'
+  const provider = {} as Provider
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('when no identity exists in SSO storage', () => {
+    it('should generate a new identity and store it', async () => {
+      const freshIdentity = createMockIdentity()
+      setupGenerateIdentityMocks(freshIdentity)
+
+      const result = await getIdentitySignature(address, provider)
+
+      expect(result).toBe(freshIdentity)
+      expect(mockLocalStorageStoreIdentity).toHaveBeenCalledWith(address, freshIdentity)
+      expect(mockAuthenticator.initializeAuthChain).toHaveBeenCalledWith(
+        address,
+        expect.any(Object),
+        MOBILE_EPHEMERAL_MINUTES,
+        expect.any(Function)
+      )
+    })
+  })
+
+  describe('when a valid identity already exists in SSO storage', () => {
+    it('should still generate a fresh identity and overwrite SSO storage', async () => {
+      const freshIdentity = createMockIdentity({ privateKey: '0x' + '11'.repeat(32) })
+      setupGenerateIdentityMocks(freshIdentity)
+
+      const result = await getIdentitySignature(address, provider)
+
+      expect(result).toBe(freshIdentity)
+      expect(mockLocalStorageStoreIdentity).toHaveBeenCalledWith(address, freshIdentity)
+      expect(mockAuthenticator.initializeAuthChain).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when called twice in a row for the same wallet', () => {
+    it('should generate two distinct identities and overwrite SSO storage each time', async () => {
+      const firstIdentity = createMockIdentity({ privateKey: '0x' + '11'.repeat(32) })
+      const secondIdentity = createMockIdentity({ privateKey: '0x' + '22'.repeat(32) })
+
+      setupGenerateIdentityMocks(firstIdentity)
+      const first = await getIdentitySignature(address, provider)
+
+      mockAuthenticator.initializeAuthChain.mockResolvedValueOnce(secondIdentity)
+      const second = await getIdentitySignature(address, provider)
+
+      expect(first).toBe(firstIdentity)
+      expect(second).toBe(secondIdentity)
+      expect(first).not.toBe(second)
+      expect(mockLocalStorageStoreIdentity).toHaveBeenNthCalledWith(1, address, firstIdentity)
+      expect(mockLocalStorageStoreIdentity).toHaveBeenNthCalledWith(2, address, secondIdentity)
+      expect(mockAuthenticator.initializeAuthChain).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/src/components/Pages/MobileAuthPage/identityUtils.ts
+++ b/src/components/Pages/MobileAuthPage/identityUtils.ts
@@ -2,7 +2,7 @@ import { createWalletClient, custom } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { mainnet } from 'viem/chains'
 import { AuthIdentity, Authenticator } from '@dcl/crypto'
-import { localStorageGetIdentity, localStorageStoreIdentity } from '@dcl/single-sign-on-client'
+import { localStorageStoreIdentity } from '@dcl/single-sign-on-client'
 import { Provider } from 'decentraland-connect'
 
 const ONE_MONTH_IN_MINUTES = 60 * 24 * 30
@@ -36,13 +36,10 @@ async function generateIdentity(address: string, provider: Provider): Promise<Au
   return generateIdentityWithSigner(address, message => walletClient.signMessage({ account, message }))
 }
 
+// Always generates a fresh ephemeral and overwrites any existing identity in SSO storage.
+// See src/shared/connection/identity.ts for the full rationale — short-circuiting on a
+// cached identity would mean dapps reading SSO storage cannot detect a re-signin.
 export async function getIdentitySignature(address: string, provider: Provider): Promise<AuthIdentity> {
-  const ssoIdentity = localStorageGetIdentity(address)
-
-  if (ssoIdentity) {
-    return ssoIdentity
-  }
-
   const identity = await generateIdentity(address, provider)
   localStorageStoreIdentity(address, identity)
   return identity

--- a/src/shared/connection/identity.spec.ts
+++ b/src/shared/connection/identity.spec.ts
@@ -139,72 +139,41 @@ describe('getIdentitySignature', () => {
     })
   })
 
-  describe('when a valid cached identity exists', () => {
-    it('should return the cached identity without regenerating', async () => {
+  describe('when a valid cached identity already exists', () => {
+    it('should still generate a fresh identity and overwrite SSO storage', async () => {
       const cachedIdentity = createMockIdentity()
+      const freshIdentity = createMockIdentity({ privateKey: '0x' + '11'.repeat(32) })
       mockLocalStorageGetIdentity.mockReturnValue(cachedIdentity)
-
-      const result = await getIdentitySignature(address, provider)
-
-      expect(result).toBe(cachedIdentity)
-      expect(mockLocalStorageStoreIdentity).not.toHaveBeenCalled()
-      expect(mockAuthenticator.initializeAuthChain).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('when the cached identity has a double-encoded private key', () => {
-    it('should discard it and generate a new identity', async () => {
-      const invalidIdentity = createMockIdentity({ privateKey: DOUBLE_ENCODED_PRIVATE_KEY })
-      const freshIdentity = createMockIdentity()
-      mockLocalStorageGetIdentity.mockReturnValue(invalidIdentity)
       setupGenerateIdentityMocks(freshIdentity)
 
       const result = await getIdentitySignature(address, provider)
 
       expect(result).toBe(freshIdentity)
+      expect(result).not.toBe(cachedIdentity)
       expect(mockLocalStorageStoreIdentity).toHaveBeenCalledWith(address, freshIdentity)
+      expect(mockAuthenticator.initializeAuthChain).toHaveBeenCalledTimes(1)
     })
   })
 
-  describe('when the cached identity has a double-encoded public key', () => {
-    it('should discard it and generate a new identity', async () => {
-      const invalidIdentity = createMockIdentity({ publicKey: DOUBLE_ENCODED_PUBLIC_KEY })
-      const freshIdentity = createMockIdentity()
-      mockLocalStorageGetIdentity.mockReturnValue(invalidIdentity)
-      setupGenerateIdentityMocks(freshIdentity)
+  describe('when called twice in a row for the same wallet', () => {
+    it('should generate two distinct identities and overwrite SSO storage each time', async () => {
+      const firstIdentity = createMockIdentity({ privateKey: '0x' + '11'.repeat(32) })
+      const secondIdentity = createMockIdentity({ privateKey: '0x' + '22'.repeat(32) })
 
-      const result = await getIdentitySignature(address, provider)
+      mockLocalStorageGetIdentity.mockReturnValue(null)
+      setupGenerateIdentityMocks(firstIdentity)
+      const first = await getIdentitySignature(address, provider)
 
-      expect(result).toBe(freshIdentity)
-      expect(mockLocalStorageStoreIdentity).toHaveBeenCalledWith(address, freshIdentity)
-    })
-  })
+      mockLocalStorageGetIdentity.mockReturnValue(firstIdentity)
+      mockAuthenticator.initializeAuthChain.mockResolvedValueOnce(secondIdentity)
+      const second = await getIdentitySignature(address, provider)
 
-  describe('when the cached identity has an invalid address', () => {
-    it('should discard it and generate a new identity', async () => {
-      const invalidIdentity = createMockIdentity({ address: '0xinvalid' })
-      const freshIdentity = createMockIdentity()
-      mockLocalStorageGetIdentity.mockReturnValue(invalidIdentity)
-      setupGenerateIdentityMocks(freshIdentity)
-
-      const result = await getIdentitySignature(address, provider)
-
-      expect(result).toBe(freshIdentity)
-      expect(mockLocalStorageStoreIdentity).toHaveBeenCalledWith(address, freshIdentity)
-    })
-  })
-
-  describe('when the cached identity has a non-hex private key', () => {
-    it('should discard it and generate a new identity', async () => {
-      const invalidIdentity = createMockIdentity({ privateKey: 'not-a-hex-key' })
-      const freshIdentity = createMockIdentity()
-      mockLocalStorageGetIdentity.mockReturnValue(invalidIdentity)
-      setupGenerateIdentityMocks(freshIdentity)
-
-      const result = await getIdentitySignature(address, provider)
-
-      expect(result).toBe(freshIdentity)
-      expect(mockLocalStorageStoreIdentity).toHaveBeenCalledWith(address, freshIdentity)
+      expect(first).toBe(firstIdentity)
+      expect(second).toBe(secondIdentity)
+      expect(first).not.toBe(second)
+      expect(mockLocalStorageStoreIdentity).toHaveBeenNthCalledWith(1, address, firstIdentity)
+      expect(mockLocalStorageStoreIdentity).toHaveBeenNthCalledWith(2, address, secondIdentity)
+      expect(mockAuthenticator.initializeAuthChain).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/src/shared/connection/identity.ts
+++ b/src/shared/connection/identity.ts
@@ -62,12 +62,12 @@ function getCachedIdentity(address: string): AuthIdentity | undefined {
   return cached
 }
 
+// Always generates a fresh ephemeral and overwrites any existing identity in SSO storage.
+// Rotating the ephemeral on every sign-in is the only signal cross-domain consumers
+// (e.g. dapps reading SSO storage) have to detect "the user just re-signed in with this
+// wallet". Short-circuiting on a cached identity makes that detection impossible because
+// storage looks identical before and after.
 async function getIdentitySignature(address: string, provider: Provider): Promise<AuthIdentity> {
-  const cached = getCachedIdentity(address)
-  if (cached) {
-    return cached
-  }
-
   const identity = await generateIdentity(address, provider)
   localStorageStoreIdentity(address, identity)
   return identity


### PR DESCRIPTION
A user already signed in with wallet A who completes a sign-in for wallet B on auth-site (`/auth/login`) was not getting their SSO identity rewritten when a valid identity already existed for the target address. As a result, dapps reading SSO storage had no observable signal that a new sign-in happened — the entry for that wallet looked identical before and after — and could not switch the active wallet to B.

`getIdentitySignature(address, provider)` in `src/shared/connection/identity.ts` and the duplicate in `src/components/Pages/MobileAuthPage/identityUtils.ts` now always generate a fresh ephemeral via `generateIdentity()` and overwrite SSO storage via `localStorageStoreIdentity()`, regardless of whether a valid cached identity exists. The on-chain wallet address does not change; only the ephemeral key (and its expiration) rotates.

Read-only consumers of cached identities (`getCachedIdentity` in bootstrap and the `accountsChanged` handler in `ConnectionProvider`) are unchanged.

## Test plan

- [x] `npx jest` — 539/539 passing, including the new regression tests in `identity.spec.ts`:
  - a valid cached identity is overwritten with a fresh one on sign-in
  - two consecutive sign-ins for the same wallet produce two distinct identities and call `localStorageStoreIdentity` twice
- [x] `npx tsc --noEmit` — clean
- [x] `eslint` over the changed files — clean
- [ ] Manual verification on `decentraland.zone`:
  1. Have two wallets (A, B) signed in in SSO storage; set `dcl:active-address` to A.
  2. Read `JSON.parse(localStorage.getItem('single-sign-on-0xWALLET_B')).authChain[1].payload`.
  3. Navigate to `/auth/login` and complete the flow signing with B.
  4. Re-read the payload — must be different (new ephemeral pubkey, new expiration).
  5. Back on the consumer dapp, active wallet should switch to B.