### PR TITLE
fix: prevent personal_sign from replicating dcl_personal_sign sign-in

### DIFF
--- a/src/components/Pages/RequestPage/RequestPage.spec.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.spec.tsx
@@ -4,7 +4,13 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { render, screen, waitFor } from '@testing-library/react'
 import { ProviderType } from '@dcl/schemas'
 import { fetchProfile } from '../../../modules/profile'
-import { DifferentSenderError, ExpiredRequestError, IpValidationError, RequestFulfilledError } from '../../../shared/auth'
+import {
+  DifferentSenderError,
+  ExpiredRequestError,
+  ImpersonatedSignInError,
+  IpValidationError,
+  RequestFulfilledError
+} from '../../../shared/auth'
 import { isProfileComplete } from '../../../shared/profile'
 import { FeatureFlagsContext } from '../../FeatureFlagsProvider'
 import { RequestPage } from './RequestPage'
@@ -377,6 +383,21 @@ describe('RequestPage', () => {
         renderRequestPage()
         await waitFor(() => {
           expect(screen.getByTestId('recover-error')).toBeInTheDocument()
+        })
+      })
+    })
+
+    describe('and recovery fails with an ImpersonatedSignInError', () => {
+      beforeEach(() => {
+        mockGetAddresses.mockResolvedValue(['0xabc123'])
+        mockEnsureProfile.mockResolvedValue({ avatars: [{ name: 'User' }] })
+        mockRecover.mockRejectedValue(new ImpersonatedSignInError('personal_sign'))
+      })
+
+      it('should show the signing error view instead of offering a retry', async () => {
+        renderRequestPage()
+        await waitFor(() => {
+          expect(screen.getByTestId('signing-error')).toBeInTheDocument()
         })
       })
     })

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -18,6 +18,7 @@ import { fetchProfile } from '../../../modules/profile'
 import {
   DifferentSenderError,
   ExpiredRequestError,
+  ImpersonatedSignInError,
   IpValidationError,
   RecoverResponse,
   RequestFulfilledError,
@@ -470,6 +471,13 @@ export const RequestPage = () => {
           // Request was already consumed successfully — not an error, stop re-fetching
           hasCompletedRef.current = true
           setView(View.VERIFY_SIGN_IN_COMPLETE)
+          return
+        } else if (e instanceof ImpersonatedSignInError) {
+          // A non-dcl_personal_sign request tried to sign a sign-in payload. Block it
+          // outright instead of offering a retry that would re-trigger the same attack.
+          hasCompletedRef.current = true
+          setError(isErrorWithMessage(e) ? e.message : 'Unknown error')
+          setView(View.VERIFY_SIGN_IN_ERROR)
           return
         }
 

--- a/src/shared/auth/errors.ts
+++ b/src/shared/auth/errors.ts
@@ -48,4 +48,26 @@ class TimedOutError extends Error {
   }
 }
 
-export { DifferentSenderError, ExpiredRequestError, RequestNotFoundError, RequestFulfilledError, IpValidationError, TimedOutError }
+/**
+ * Thrown when a request whose method is not `dcl_personal_sign` (e.g. a plain
+ * `personal_sign`) asks the user to sign a Decentraland identity-authorization
+ * payload. Allowing it would let a malicious site replicate the `dcl_personal_sign`
+ * sign-in flow through the generic signing path, bypassing its protections, and
+ * obtain a valid auth chain that impersonates the user.
+ */
+class ImpersonatedSignInError extends Error {
+  constructor(public readonly method: string) {
+    super(`The "${method}" method cannot be used to sign a Decentraland sign-in payload`)
+    this.name = 'ImpersonatedSignInError'
+  }
+}
+
+export {
+  DifferentSenderError,
+  ExpiredRequestError,
+  RequestNotFoundError,
+  RequestFulfilledError,
+  IpValidationError,
+  TimedOutError,
+  ImpersonatedSignInError
+}

--- a/src/shared/auth/httpClient.spec.ts
+++ b/src/shared/auth/httpClient.spec.ts
@@ -2,7 +2,7 @@ import { AuthIdentity } from '@dcl/crypto'
 import signedFetchMock from 'decentraland-crypto-fetch'
 import { getAnalytics } from '../../modules/analytics/segment'
 import { config } from '../../modules/config'
-import { DifferentSenderError, ExpiredRequestError, RequestNotFoundError } from './errors'
+import { DifferentSenderError, ExpiredRequestError, ImpersonatedSignInError, RequestNotFoundError } from './errors'
 import { createAuthServerHttpClient } from './httpClient'
 import { RecoverResponse } from './types'
 // Mock dependencies
@@ -136,6 +136,27 @@ describe('createAuthServerClient', () => {
 
       it('should throw the network error', async () => {
         await expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toThrow('Network error')
+      })
+    })
+
+    describe('when a non dcl_personal_sign method carries a sign-in payload', () => {
+      beforeEach(() => {
+        mockResponse.method = 'personal_sign'
+        mockResponse.params = [
+          [
+            'Decentraland Login',
+            'Ephemeral address: 0x1234567890123456789012345678901234567890',
+            'Expiration: 2100-01-01T00:00:00.000Z'
+          ].join('\n')
+        ]
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockResponse)
+        })
+      })
+
+      it('should throw an ImpersonatedSignInError', async () => {
+        await expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toBeInstanceOf(ImpersonatedSignInError)
       })
     })
   })

--- a/src/shared/auth/httpClient.ts
+++ b/src/shared/auth/httpClient.ts
@@ -5,6 +5,7 @@ import { config } from '../../modules/config'
 import { trackEvent } from '../utils/analytics'
 import { handleError } from '../utils/errorHandler'
 import { DifferentSenderError, ExpiredRequestError, IpValidationError, RequestFulfilledError, RequestNotFoundError } from './errors'
+import { assertRequestIsNotImpersonatingSignIn } from './signMethodGuard'
 import { IdentityResponse, OutcomeError, OutcomeResponse, RecoverResponse } from './types'
 export const createAuthServerHttpClient = (authServerUrl?: string) => {
   const baseUrl = authServerUrl ?? config.get('AUTH_SERVER_URL')
@@ -145,6 +146,10 @@ export const createAuthServerHttpClient = (authServerUrl?: string) => {
       if (recoverResponse.expiration && new Date(recoverResponse.expiration) < new Date()) {
         throw new ExpiredRequestError(requestId, recoverResponse.expiration)
       }
+
+      // Reject requests that try to replicate the dcl_personal_sign sign-in through a
+      // generic signing method (e.g. personal_sign), which would bypass its protections.
+      assertRequestIsNotImpersonatingSignIn(recoverResponse.method, recoverResponse.params)
 
       switch (recoverResponse.method) {
         case 'dcl_personal_sign':

--- a/src/shared/auth/index.ts
+++ b/src/shared/auth/index.ts
@@ -1,4 +1,5 @@
 export * from './errors'
 export * from './httpClient'
+export * from './signMethodGuard'
 export * from './types'
 export * from './wsClient'

--- a/src/shared/auth/signMethodGuard.spec.ts
+++ b/src/shared/auth/signMethodGuard.spec.ts
@@ -1,0 +1,175 @@
+import { ImpersonatedSignInError } from './errors'
+import { assertRequestIsNotImpersonatingSignIn, isDecentralandIdentityAuthMessage } from './signMethodGuard'
+
+describe('isDecentralandIdentityAuthMessage', () => {
+  describe('when the message is a canonical Decentraland sign-in payload', () => {
+    let message: string
+
+    beforeEach(() => {
+      message = [
+        'Decentraland Login',
+        'Ephemeral address: 0x1234567890123456789012345678901234567890',
+        'Expiration: 2100-01-01T00:00:00.000Z'
+      ].join('\n')
+    })
+
+    it('should return true', () => {
+      expect(isDecentralandIdentityAuthMessage(message)).toBe(true)
+    })
+  })
+
+  describe('when the message uses a forged first line but keeps the ephemeral structure', () => {
+    let message: string
+
+    beforeEach(() => {
+      message = [
+        'Please sign in to my totally legit dapp',
+        'Ephemeral address: 0x1234567890123456789012345678901234567890',
+        'Expiration: 2100-01-01T00:00:00.000Z'
+      ].join('\n')
+    })
+
+    it('should return true because the auth-chain validator ignores the first line', () => {
+      expect(isDecentralandIdentityAuthMessage(message)).toBe(true)
+    })
+  })
+
+  describe('when the message uses carriage returns between lines', () => {
+    let message: string
+
+    beforeEach(() => {
+      message =
+        'Decentraland Login\r\nEphemeral address: 0x1234567890123456789012345678901234567890\r\nExpiration: 2100-01-01T00:00:00.000Z'
+    })
+
+    it('should return true after normalizing the carriage returns', () => {
+      expect(isDecentralandIdentityAuthMessage(message)).toBe(true)
+    })
+  })
+
+  describe('when the message is a regular text to be signed', () => {
+    let message: string
+
+    beforeEach(() => {
+      message = 'Sign this message to prove you own this wallet'
+    })
+
+    it('should return false', () => {
+      expect(isDecentralandIdentityAuthMessage(message)).toBe(false)
+    })
+  })
+
+  describe('when the message has fewer than three lines', () => {
+    let message: string
+
+    beforeEach(() => {
+      message = 'Decentraland Login\nEphemeral address: 0x1234567890123456789012345678901234567890'
+    })
+
+    it('should return false', () => {
+      expect(isDecentralandIdentityAuthMessage(message)).toBe(false)
+    })
+  })
+
+  describe('when the ephemeral address line is not a hex address', () => {
+    let message: string
+
+    beforeEach(() => {
+      message = ['Decentraland Login', 'Ephemeral address: not-an-address', 'Expiration: 2100-01-01T00:00:00.000Z'].join('\n')
+    })
+
+    it('should return false', () => {
+      expect(isDecentralandIdentityAuthMessage(message)).toBe(false)
+    })
+  })
+
+  describe('when the value is not a string', () => {
+    let message: unknown
+
+    beforeEach(() => {
+      message = { foo: 'bar' }
+    })
+
+    it('should return false', () => {
+      expect(isDecentralandIdentityAuthMessage(message)).toBe(false)
+    })
+  })
+})
+
+describe('assertRequestIsNotImpersonatingSignIn', () => {
+  let signInPayload: string
+
+  beforeEach(() => {
+    signInPayload = [
+      'Decentraland Login',
+      'Ephemeral address: 0x1234567890123456789012345678901234567890',
+      'Expiration: 2100-01-01T00:00:00.000Z'
+    ].join('\n')
+  })
+
+  describe('when the method is dcl_personal_sign', () => {
+    let params: unknown[]
+
+    beforeEach(() => {
+      params = [signInPayload]
+    })
+
+    it('should not throw even when the message is a sign-in payload', () => {
+      expect(() => assertRequestIsNotImpersonatingSignIn('dcl_personal_sign', params)).not.toThrow()
+    })
+  })
+
+  describe('when the method is personal_sign and the message is a sign-in payload', () => {
+    let params: unknown[]
+
+    beforeEach(() => {
+      params = [signInPayload]
+    })
+
+    it('should throw an ImpersonatedSignInError', () => {
+      expect(() => assertRequestIsNotImpersonatingSignIn('personal_sign', params)).toThrow(ImpersonatedSignInError)
+    })
+  })
+
+  describe('when the method is eth_sign and the sign-in payload is not the first param', () => {
+    let params: unknown[]
+
+    beforeEach(() => {
+      params = ['0x1234567890123456789012345678901234567890', signInPayload]
+    })
+
+    it('should throw an ImpersonatedSignInError regardless of the param order', () => {
+      expect(() => assertRequestIsNotImpersonatingSignIn('eth_sign', params)).toThrow(ImpersonatedSignInError)
+    })
+  })
+
+  describe('when the method is personal_sign and the message is a regular text', () => {
+    let params: unknown[]
+
+    beforeEach(() => {
+      params = ['Sign this message to prove you own this wallet']
+    })
+
+    it('should not throw', () => {
+      expect(() => assertRequestIsNotImpersonatingSignIn('personal_sign', params)).not.toThrow()
+    })
+  })
+
+  describe('when the method is eth_sendTransaction with object params', () => {
+    let params: unknown[]
+
+    beforeEach(() => {
+      params = [{ to: '0xcontract', data: '0x1234', value: '0' }]
+    })
+
+    it('should not throw', () => {
+      expect(() => assertRequestIsNotImpersonatingSignIn('eth_sendTransaction', params)).not.toThrow()
+    })
+  })
+
+  describe('when the request has no params', () => {
+    it('should not throw', () => {
+      expect(() => assertRequestIsNotImpersonatingSignIn('personal_sign', undefined)).not.toThrow()
+    })
+  })
+})

--- a/src/shared/auth/signMethodGuard.ts
+++ b/src/shared/auth/signMethodGuard.ts
@@ -1,0 +1,57 @@
+import { ImpersonatedSignInError } from './errors'
+
+// The Decentraland-specific signing method used by the sign-in flow. It is the only
+// method allowed to produce a signature over an identity-authorization payload.
+const DCL_SIGN_IN_METHOD = 'dcl_personal_sign'
+
+// A Decentraland identity-authorization message (built by @dcl/crypto's
+// `Authenticator.getEphemeralMessage`) looks like:
+//
+//   Decentraland Login
+//   Ephemeral address: 0x<address>
+//   Expiration: <ISO timestamp>
+//
+// When validating an auth chain, @dcl/crypto's `parseEmphemeralPayload` strips `\r`,
+// splits on `\n`, and only reads the 2nd line (ephemeral address) and 3rd line
+// (expiration) — the first "human readable" line is ignored. A forged message can
+// therefore use any header and still yield a usable ephemeral auth chain, so we match
+// that same structure rather than the literal "Decentraland Login" header.
+const EPHEMERAL_ADDRESS_LINE_PREFIX = 'Ephemeral address: 0x'
+const EXPIRATION_LINE_PREFIX = 'Expiration: '
+
+/**
+ * Returns whether a message replicates the Decentraland identity-authorization payload
+ * that the `dcl_personal_sign` sign-in flow asks the user to sign. Detection mirrors how
+ * @dcl/crypto validates the payload so that any message which would yield a usable auth
+ * chain is caught, regardless of its first line.
+ */
+function isDecentralandIdentityAuthMessage(message: unknown): boolean {
+  if (typeof message !== 'string') {
+    return false
+  }
+
+  const lines = message.replace(/\r/g, '').split('\n')
+  if (lines.length < 3) {
+    return false
+  }
+
+  return lines[1].startsWith(EPHEMERAL_ADDRESS_LINE_PREFIX) && lines[2].startsWith(EXPIRATION_LINE_PREFIX)
+}
+
+/**
+ * Guards a recovered request against sign-in impersonation. Any method other than
+ * `dcl_personal_sign` that carries a Decentraland identity-authorization payload in its
+ * params is rejected with an {@link ImpersonatedSignInError}, since signing it would
+ * grant the requester an auth chain that impersonates the user.
+ */
+function assertRequestIsNotImpersonatingSignIn(method: string, params: unknown[] | undefined): void {
+  if (method === DCL_SIGN_IN_METHOD) {
+    return
+  }
+
+  if (params?.some(isDecentralandIdentityAuthMessage)) {
+    throw new ImpersonatedSignInError(method)
+  }
+}
+
+export { DCL_SIGN_IN_METHOD, isDecentralandIdentityAuthMessage, assertRequestIsNotImpersonatingSignIn }

--- a/src/shared/auth/wsClient.spec.ts
+++ b/src/shared/auth/wsClient.spec.ts
@@ -1,7 +1,7 @@
 import { io } from 'socket.io-client'
 import { getAnalytics } from '../../modules/analytics/segment'
 import { config } from '../../modules/config'
-import { DifferentSenderError, ExpiredRequestError, RequestNotFoundError } from './errors'
+import { DifferentSenderError, ExpiredRequestError, ImpersonatedSignInError, RequestNotFoundError } from './errors'
 import { RecoverResponse } from './types'
 import { createAuthServerWsClient } from './wsClient'
 
@@ -138,6 +138,23 @@ describe('createAuthServerClient', () => {
 
       it('should throw the network error', async () => {
         await expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toThrow('Network error')
+      })
+    })
+
+    describe('when a non dcl_personal_sign method carries a sign-in payload', () => {
+      beforeEach(() => {
+        mockResponse.method = 'personal_sign'
+        mockResponse.params = [
+          [
+            'Decentraland Login',
+            'Ephemeral address: 0x1234567890123456789012345678901234567890',
+            'Expiration: 2100-01-01T00:00:00.000Z'
+          ].join('\n')
+        ]
+      })
+
+      it('should throw an ImpersonatedSignInError', async () => {
+        await expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toBeInstanceOf(ImpersonatedSignInError)
       })
     })
   })

--- a/src/shared/auth/wsClient.ts
+++ b/src/shared/auth/wsClient.ts
@@ -4,6 +4,7 @@ import { config } from '../../modules/config'
 import { trackEvent } from '../utils/analytics'
 import { handleError } from '../utils/errorHandler'
 import { DifferentSenderError, ExpiredRequestError, IpValidationError, RequestFulfilledError, RequestNotFoundError } from './errors'
+import { assertRequestIsNotImpersonatingSignIn } from './signMethodGuard'
 import { OutcomeError, OutcomeResponse, RecoverResponse, ValidationResponse } from './types'
 
 export const createAuthServerWsClient = (authServerUrl?: string) => {
@@ -83,6 +84,10 @@ export const createAuthServerWsClient = (authServerUrl?: string) => {
       if (response.expiration && new Date(response.expiration) < new Date()) {
         throw new ExpiredRequestError(requestId, response.expiration)
       }
+
+      // Reject requests that try to replicate the dcl_personal_sign sign-in through a
+      // generic signing method (e.g. personal_sign), which would bypass its protections.
+      assertRequestIsNotImpersonatingSignIn(response.method, response.params)
 
       switch (response.method) {
         case 'dcl_personal_sign':


### PR DESCRIPTION
## Why

`dcl_personal_sign` is Decentraland's sign-in method. Its payload is the identity-authorization message (`Decentraland Login` / `Ephemeral address:` / `Expiration:`), and signing it produces an auth chain that lets the requester act on the user's behalf for the ephemeral key's lifetime. It is handled through the protected sign-in verification flow (`VERIFY_SIGN_IN`, validation notify, verification code).

A plain `personal_sign` request, by contrast, can carry **any** message and is routed through the generic wallet-interaction path. A malicious site can therefore craft a `personal_sign` request whose message is exactly the identity-authorization payload, harvest a valid auth chain through the generic path, and **bypass the sign-in protections** — effectively impersonating the user.

This is made worse by how `@dcl/crypto` validates the payload: `parseEmphemeralPayload` only reads the *ephemeral address* (line 2) and *expiration* (line 3) — the first "human readable" line is ignored. So a forged message can use any header and still yield a usable auth chain. Detection must therefore match that **structure**, not the literal `Decentraland Login` header.

## What

Enforce the rule that **only `dcl_personal_sign` may sign an identity-authorization payload**:

- **`signMethodGuard.ts`** (new): `isDecentralandIdentityAuthMessage()` detects the payload structurally (mirroring the crypto validator), and `assertRequestIsNotImpersonatingSignIn(method, params)` throws when any method other than `dcl_personal_sign` carries it. It scans **all** params, so a reordered `[address, message]` (e.g. `eth_sign`) is also caught.
- **`errors.ts`**: new `ImpersonatedSignInError` typed error (reported to Sentry, since it signals a possible attack).
- **`httpClient.ts` / `wsClient.ts`**: the guard runs inside `recover()` — the single chokepoint every signing flow (`RequestPage`, `useSignRequest`) passes through — so a blocked request never reaches `signMessage`.
- **`RequestPage.tsx`**: surfaces the rejection via the `SigningError` view (close-the-window) instead of the retryable `RecoverError` view, which would just re-trigger the attack.

## Test plan

- [x] `isDecentralandIdentityAuthMessage` returns true for canonical, forged-header, and `\r\n` payloads; false for regular text, <3 lines, non-hex address, and non-strings.
- [x] `assertRequestIsNotImpersonatingSignIn` allows `dcl_personal_sign` with the payload, throws for `personal_sign`/`eth_sign` carrying it (any param position), and is a no-op for benign messages, `eth_sendTransaction`, and missing params.
- [x] `recover()` throws `ImpersonatedSignInError` in both HTTP and WS clients when a non-`dcl_personal_sign` method carries a sign-in payload.
- [x] `RequestPage` shows the signing-error view (not the retryable recover-error view) on `ImpersonatedSignInError`.
- [x] `tsc --noEmit`, `eslint`, and the full affected test suite pass (74 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)