### PR TITLE
fix: offer injected metamask on ios for in-app browser logins

### DIFF
--- a/src/hooks/targetConfig.spec.ts
+++ b/src/hooks/targetConfig.spec.ts
@@ -134,6 +134,20 @@ describe('useTargetConfig', () => {
       expect(config.connectionOptions.primary).toBe(ConnectionOptionType.APPLE)
       expect(config.connectionOptions.secondary).toBe(ConnectionOptionType.GOOGLE)
     })
+
+    it('should include WALLET_CONNECT in extraOptions', () => {
+      const { result } = renderHook(() => useTargetConfig())
+      const [config] = result.current
+
+      expect(config.connectionOptions.extraOptions).toContain(ConnectionOptionType.WALLET_CONNECT)
+    })
+
+    it('should include METAMASK in extraOptions', () => {
+      const { result } = renderHook(() => useTargetConfig())
+      const [config] = result.current
+
+      expect(config.connectionOptions.extraOptions).toContain(ConnectionOptionType.METAMASK)
+    })
   })
 
   describe('when on Android mobile with no targetConfigId', () => {

--- a/src/hooks/targetConfig.ts
+++ b/src/hooks/targetConfig.ts
@@ -61,7 +61,12 @@ const targetConfigs: Record<TargetConfigId, TargetConfig> = {
     connectionOptions: {
       primary: ConnectionOptionType.APPLE,
       secondary: ConnectionOptionType.GOOGLE,
-      extraOptions: [ConnectionOptionType.WALLET_CONNECT]
+      // Include both wallet options for parity with Android: MetaMask covers the
+      // in-app DApp Browser path (connects through the injected provider directly,
+      // with no WalletConnect relay/app-switching back-and-forth), WalletConnect
+      // covers every other mobile wallet (Trust, Rainbow, etc.). The
+      // MetaMask option auto-disables in regular Safari where no provider is injected.
+      extraOptions: [ConnectionOptionType.METAMASK, ConnectionOptionType.WALLET_CONNECT]
     }
   },
   android: {


### PR DESCRIPTION
## Changes

- Add `ConnectionOptionType.METAMASK` to the **iOS** target config's `extraOptions`, mirroring the existing Android config.
- `METAMASK` maps to `ProviderType.INJECTED`, so inside MetaMask's in-app DApp browser on iOS the login now connects directly through `window.ethereum` instead of being forced through WalletConnect.
- The option auto-disables (via `shouldDisableMetaMask`) in regular Safari where no provider is injected — no regression for users outside the in-app browser.
- Add iOS spec tests mirroring the existing Android coverage.

## Why

On iOS the only wallet option was WalletConnect. Even when a user was already inside MetaMask's in-app browser — where a direct, instant injected connection is available — they were routed through WalletConnect, which on mobile deep-links out to a wallet app and round-trips for both connect and signature. That is the "back-and-forth / not smooth" behavior users reported. Android already exposed the injected MetaMask path (`InjectedConnector`); this brings iOS to parity.

## Test plan

- [x] `npm run lint`, `npm run lint:pkg`, `npm run build`, `npm test` (560 passing)
- [ ] Manual: open auth inside MetaMask's iOS in-app browser → MetaMask option enabled → connects directly, no app-switching
- [ ] Manual: open auth in regular iOS Safari → MetaMask option disabled, WalletConnect unaffected