### PR TITLE
feat: forward bridge-only query param to the client deep link

### DIFF
--- a/src/components/Pages/RequestPage/Container/Container.tsx
+++ b/src/components/Pages/RequestPage/Container/Container.tsx
@@ -6,6 +6,7 @@ import { useMobileMediaQuery } from 'decentraland-ui2'
 import { useNavigateWithSearchParams } from '../../../../hooks/navigation'
 import { useTargetConfig } from '../../../../hooks/targetConfig'
 import { useCurrentConnectionData } from '../../../../shared/connection'
+import { isBridgeOnlyEnabled } from '../../../../shared/locations'
 import { AnimatedBackground } from '../../../AnimatedBackground'
 import { CustomWearablePreview } from '../../../CustomWearablePreview'
 import styles from './Container.module.css'
@@ -20,17 +21,19 @@ export const Container = (props: { children: ReactNode; requestId?: string; canC
   const isMobile = useMobileMediaQuery()
   const { account } = useCurrentConnectionData()
   const isDeepLinkFlow = searchParams.get('flow') === 'deeplink'
+  const isBridgeOnly = isBridgeOnlyEnabled(searchParams)
 
   const onChangeAccount = useCallback(
     async (evt: React.MouseEvent<HTMLAnchorElement>) => {
       evt.preventDefault()
       await connection.disconnect()
       const flowParam = isDeepLinkFlow ? '&flow=deeplink' : ''
+      const bridgeOnlyParam = isBridgeOnly ? '&bridge-only=true' : ''
       // Don't preserve loginMethod — the user explicitly wants to choose a different method
-      const redirectToUrl = `/auth/requests/${requestId ?? ''}?targetConfigId=${targetConfigId}${flowParam}`
+      const redirectToUrl = `/auth/requests/${requestId ?? ''}?targetConfigId=${targetConfigId}${flowParam}${bridgeOnlyParam}`
       navigate(`/login?redirectTo=${encodeURIComponent(redirectToUrl)}`)
     },
-    [requestId, targetConfigId, isDeepLinkFlow]
+    [requestId, targetConfigId, isDeepLinkFlow, isBridgeOnly, navigate]
   )
 
   return (

--- a/src/components/Pages/RequestPage/RequestPage.spec.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.spec.tsx
@@ -76,7 +76,8 @@ jest.mock('../../../shared/auth', () => {
 
 // --- Shared modules ---
 jest.mock('../../../shared/locations', () => ({
-  extractReferrerFromSearchParameters: jest.fn().mockReturnValue(null)
+  extractReferrerFromSearchParameters: jest.fn().mockReturnValue(null),
+  isBridgeOnlyEnabled: jest.fn().mockReturnValue(false)
 }))
 jest.mock('../../../shared/utils/analytics', () => ({
   identifyUser: jest.fn()

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -615,7 +615,7 @@ export const RequestPage = () => {
         setIsLoading(false)
       }
     }
-  }, [setIsLoading, isUserUsingWeb2Wallet, isLoading, identity])
+  }, [setIsLoading, isUserUsingWeb2Wallet, isLoading, identity, isBridgeOnly])
 
   const onDenyWalletInteraction = useCallback(async () => {
     setIsLoading(true)

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -27,7 +27,7 @@ import {
 } from '../../../shared/auth'
 import { useCurrentConnectionData } from '../../../shared/connection'
 import { isErrorWithMessage, isRpcError, isUserRejectedTransaction } from '../../../shared/errors'
-import { extractReferrerFromSearchParameters } from '../../../shared/locations'
+import { extractReferrerFromSearchParameters, isBridgeOnlyEnabled } from '../../../shared/locations'
 import { sendTipNotification } from '../../../shared/notifications'
 import { isProfileComplete } from '../../../shared/profile'
 import { identifyUser } from '../../../shared/utils/analytics'
@@ -182,16 +182,20 @@ export const RequestPage = () => {
   const authServerClient = useRef(createAuthServerHttpClient())
   const isDeepLinkFlow = searchParams.get('flow') === 'deeplink'
   const flowParam = isDeepLinkFlow ? '&flow=deeplink' : ''
+  // The bridge-only flag rides inside redirectTo so it survives logins/callbacks and can be
+  // appended to the client deep link once the flow completes.
+  const isBridgeOnly = isBridgeOnlyEnabled(searchParams)
+  const bridgeOnlyParam = isBridgeOnly ? '&bridge-only=true' : ''
   // Goes to the login page where the user will have to connect a wallet.
   // Preserve loginMethod from current URL if present for auto-login functionality
   const loginMethodParam = searchParams.get('loginMethod')
 
   const toLoginPage = useCallback(() => {
-    const redirectToUrl = `/auth/requests/${requestId}?targetConfigId=${targetConfigId}${flowParam}`
+    const redirectToUrl = `/auth/requests/${requestId}?targetConfigId=${targetConfigId}${flowParam}${bridgeOnlyParam}`
     const loginMethodQuery = loginMethodParam ? `&loginMethod=${encodeURIComponent(loginMethodParam)}` : ''
     const finalUrl = `/login?redirectTo=${encodeURIComponent(redirectToUrl)}${loginMethodQuery}`
     navigate(finalUrl)
-  }, [requestId, targetConfigId, isDeepLinkFlow, loginMethodParam])
+  }, [requestId, targetConfigId, flowParam, bridgeOnlyParam, loginMethodParam, navigate])
 
   // Effect 1: Ensure profile consistency before allowing request loading.
   // Navigates to setup if the profile is incomplete or missing.
@@ -212,7 +216,7 @@ export const RequestPage = () => {
     let cancelled = false
 
     const checkProfile = async () => {
-      const redirectTo = `/auth/requests/${requestId}?targetConfigId=${targetConfigId}${flowParam}`
+      const redirectTo = `/auth/requests/${requestId}?targetConfigId=${targetConfigId}${flowParam}${bridgeOnlyParam}`
       const referrer = extractReferrerFromSearchParameters(searchParams)
       const profile = await ensureProfile(account, identityRef.current, { redirectTo, referrer })
 
@@ -236,6 +240,7 @@ export const RequestPage = () => {
     requestId,
     targetConfigId,
     flowParam,
+    bridgeOnlyParam,
     searchParams,
     skipSetup
   ])
@@ -569,8 +574,10 @@ export const RequestPage = () => {
         setView(View.VERIFY_SIGN_IN_COMPLETE)
         // For mobile deep-link flow, auto-redirect. For Explorer (skipSetup),
         // the SignInCompletePage shows a Continue button that triggers the deeplink.
+        // Route through getExplorerDeeplink so this bare redirect carries the same
+        // query params (dclenv, bridge-only) as the other deep-link generation sites.
         if (targetConfig.deepLink) {
-          window.location.href = targetConfig.deepLink
+          window.location.href = getExplorerDeeplink(targetConfig.deepLink, isBridgeOnly)
         }
       }
     } catch (e) {
@@ -792,7 +799,7 @@ export const RequestPage = () => {
       return (
         <RecoverError
           onTryAgain={() => {
-            window.location.href = getExplorerDeeplink(targetConfig.deepLink)
+            window.location.href = getExplorerDeeplink(targetConfig.deepLink, isBridgeOnly)
           }}
         />
       )
@@ -803,12 +810,18 @@ export const RequestPage = () => {
       // From Explorer (skipSetup enabled): show full-page success with Continue button
       // From web (has redirectTo): show minimal success view
       return skipSetup ? (
-        <SignInCompletePage skipRedirect={skipDeepLinkRedirect} deepLink={targetConfig.deepLink} />
+        <SignInCompletePage skipRedirect={skipDeepLinkRedirect} deepLink={targetConfig.deepLink} bridgeOnly={isBridgeOnly} />
       ) : (
         <SignInComplete />
       )
     case View.DEEP_LINK_CONTINUE_IN_APP:
-      return <ContinueInApp onContinue={onContinueInApp} requestId={requestId} deepLinkUrl={`${targetConfig.deepLink || 'decentraland://'}open?signin=${identityId}`} />
+      return (
+        <ContinueInApp
+          onContinue={onContinueInApp}
+          requestId={requestId}
+          deepLinkUrl={`${targetConfig.deepLink || 'decentraland://'}open?signin=${identityId}${bridgeOnlyParam}`}
+        />
+      )
     case View.VERIFY_SIGN_IN_DENIED:
       return <DeniedSignIn requestId={requestId} />
     case View.WALLET_INTERACTION_COMPLETE:

--- a/src/components/Pages/RequestPage/Views/SignInCompletePage.spec.tsx
+++ b/src/components/Pages/RequestPage/Views/SignInCompletePage.spec.tsx
@@ -1,0 +1,82 @@
+import { config } from '../../../../modules/config'
+import { getExplorerDeeplink } from './SignInCompletePage'
+
+jest.mock('../../../../modules/config', () => ({
+  config: {
+    get: jest.fn()
+  }
+}))
+
+const mockedConfigGet = config.get as jest.MockedFunction<typeof config.get>
+
+describe('getExplorerDeeplink', () => {
+  let deepLink: string | undefined
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('when the environment is production', () => {
+    beforeEach(() => {
+      mockedConfigGet.mockReturnValue('production')
+      deepLink = 'decentraland://'
+    })
+
+    describe('and bridge-only is disabled', () => {
+      it('should return the bare deep link without query params', () => {
+        expect(getExplorerDeeplink(deepLink, false)).toBe('decentraland://')
+      })
+    })
+
+    describe('and bridge-only is enabled', () => {
+      it('should append the canonical bridge-only flag', () => {
+        expect(getExplorerDeeplink(deepLink, true)).toBe('decentraland://?bridge-only=true')
+      })
+    })
+  })
+
+  describe('when the environment is development', () => {
+    beforeEach(() => {
+      mockedConfigGet.mockReturnValue('development')
+      deepLink = 'decentraland://'
+    })
+
+    describe('and bridge-only is disabled', () => {
+      it('should append only the dclenv zone param', () => {
+        expect(getExplorerDeeplink(deepLink, false)).toBe('decentraland://?dclenv=zone')
+      })
+    })
+
+    describe('and bridge-only is enabled', () => {
+      it('should append both the dclenv zone param and the bridge-only flag', () => {
+        expect(getExplorerDeeplink(deepLink, true)).toBe('decentraland://?dclenv=zone&bridge-only=true')
+      })
+    })
+  })
+
+  describe('when the environment is a named non-production env', () => {
+    beforeEach(() => {
+      mockedConfigGet.mockReturnValue('staging')
+      deepLink = 'dcl-creator-hub://'
+    })
+
+    describe('and bridge-only is enabled', () => {
+      it('should append the raw env as dclenv alongside the bridge-only flag', () => {
+        expect(getExplorerDeeplink(deepLink, true)).toBe('dcl-creator-hub://?dclenv=staging&bridge-only=true')
+      })
+    })
+  })
+
+  describe('when no deep link is provided', () => {
+    beforeEach(() => {
+      mockedConfigGet.mockReturnValue('production')
+      deepLink = undefined
+    })
+
+    describe('and bridge-only is enabled', () => {
+      it('should fall back to the decentraland scheme with the bridge-only flag', () => {
+        expect(getExplorerDeeplink(deepLink, true)).toBe('decentraland://?bridge-only=true')
+      })
+    })
+  })
+})

--- a/src/components/Pages/RequestPage/Views/SignInCompletePage.tsx
+++ b/src/components/Pages/RequestPage/Views/SignInCompletePage.tsx
@@ -5,28 +5,36 @@ import { config } from '../../../../modules/config'
 import { AnimatedBackground } from '../../../AnimatedBackground'
 import { CenteredContainer, Description, SuccessAnimation, TextBlock, Title, TitleCheckIcon, TitleRow } from './SignInCompletePage.styled'
 
-function getExplorerDeeplink(deepLink?: string): string {
+function getExplorerDeeplink(deepLink?: string, bridgeOnly?: boolean): string {
   const env = config.get('ENVIRONMENT').toLowerCase()
   const base = deepLink || 'decentraland://'
-  if (env === 'production') return base
-  return `${base}?dclenv=${env === 'development' ? 'zone' : env}`
+  const params = new URLSearchParams()
+  if (env !== 'production') {
+    params.set('dclenv', env === 'development' ? 'zone' : env)
+  }
+  if (bridgeOnly) {
+    params.set('bridge-only', 'true')
+  }
+  const query = params.toString()
+  return query ? `${base}?${query}` : base
 }
 
 type Props = {
   onContinue?: () => void
   deepLink?: string
   skipRedirect?: boolean
+  bridgeOnly?: boolean
 }
 
-const SignInCompletePage = ({ onContinue, deepLink, skipRedirect }: Props) => {
+const SignInCompletePage = ({ onContinue, deepLink, skipRedirect, bridgeOnly }: Props) => {
   const { t } = useTranslation()
 
   useEffect(() => {
     onContinue?.()
     if (!skipRedirect) {
-      window.location.href = getExplorerDeeplink(deepLink)
+      window.location.href = getExplorerDeeplink(deepLink, bridgeOnly)
     }
-  }, [onContinue, deepLink, skipRedirect])
+  }, [onContinue, deepLink, skipRedirect, bridgeOnly])
 
   return (
     <CenteredContainer>

--- a/src/shared/locations.spec.ts
+++ b/src/shared/locations.spec.ts
@@ -263,13 +263,23 @@ describe('locations', () => {
       })
     })
 
-    describe('and the bridge-only param is present without a value', () => {
+    describe('and the bridge-only param is present as a bare flag without an equals sign', () => {
+      beforeEach(() => {
+        searchParams = new URLSearchParams('bridge-only')
+      })
+
+      it('should return true', () => {
+        expect(isBridgeOnlyEnabled(searchParams)).toBe(true)
+      })
+    })
+
+    describe('and the bridge-only param is present with an empty value', () => {
       beforeEach(() => {
         searchParams = new URLSearchParams('bridge-only=')
       })
 
-      it('should return false', () => {
-        expect(isBridgeOnlyEnabled(searchParams)).toBe(false)
+      it('should return true', () => {
+        expect(isBridgeOnlyEnabled(searchParams)).toBe(true)
       })
     })
 

--- a/src/shared/locations.spec.ts
+++ b/src/shared/locations.spec.ts
@@ -1,4 +1,4 @@
-import { extractRedirectToFromSearchParameters, extractReferrerFromSearchParameters, locations } from './locations'
+import { extractRedirectToFromSearchParameters, extractReferrerFromSearchParameters, isBridgeOnlyEnabled, locations } from './locations'
 
 describe('locations', () => {
   describe('login', () => {
@@ -216,6 +216,70 @@ describe('locations', () => {
         encodedState = btoa(JSON.stringify(stateData))
         searchParams = new URLSearchParams(`state=${encodedState}`)
         expect(extractReferrerFromSearchParameters(searchParams)).toBeNull()
+      })
+    })
+  })
+
+  describe('when checking if bridge-only is enabled', () => {
+    let searchParams: URLSearchParams
+
+    describe('and the bridge-only param is set to "true"', () => {
+      beforeEach(() => {
+        searchParams = new URLSearchParams('bridge-only=true')
+      })
+
+      it('should return true', () => {
+        expect(isBridgeOnlyEnabled(searchParams)).toBe(true)
+      })
+    })
+
+    describe('and the bridge-only param is set to "true" with different casing', () => {
+      beforeEach(() => {
+        searchParams = new URLSearchParams('bridge-only=TRUE')
+      })
+
+      it('should return true', () => {
+        expect(isBridgeOnlyEnabled(searchParams)).toBe(true)
+      })
+    })
+
+    describe('and the bridge-only param is set to "false"', () => {
+      beforeEach(() => {
+        searchParams = new URLSearchParams('bridge-only=false')
+      })
+
+      it('should return false', () => {
+        expect(isBridgeOnlyEnabled(searchParams)).toBe(false)
+      })
+    })
+
+    describe('and the bridge-only param is set to a non-boolean value', () => {
+      beforeEach(() => {
+        searchParams = new URLSearchParams('bridge-only=1')
+      })
+
+      it('should return false', () => {
+        expect(isBridgeOnlyEnabled(searchParams)).toBe(false)
+      })
+    })
+
+    describe('and the bridge-only param is present without a value', () => {
+      beforeEach(() => {
+        searchParams = new URLSearchParams('bridge-only=')
+      })
+
+      it('should return false', () => {
+        expect(isBridgeOnlyEnabled(searchParams)).toBe(false)
+      })
+    })
+
+    describe('and the bridge-only param is not present', () => {
+      beforeEach(() => {
+        searchParams = new URLSearchParams('targetConfigId=default')
+      })
+
+      it('should return false', () => {
+        expect(isBridgeOnlyEnabled(searchParams)).toBe(false)
       })
     })
   })

--- a/src/shared/locations.ts
+++ b/src/shared/locations.ts
@@ -150,11 +150,18 @@ const extractReferrerFromSearchParameters = (searchParams: URLSearchParams): str
 
 // The `bridge-only` query param is a boolean flag the auth site can be opened with.
 // It's preserved across logins/callbacks by riding inside `redirectTo`, and when enabled
-// it's forwarded onto the client deep link. Only a truthy value ("true", case-insensitive)
-// enables it — "false" or an empty value are treated as not set.
+// it's forwarded onto the client deep link. A bare flag (`?bridge-only`) or an explicit
+// `?bridge-only=true` (case-insensitive) enable it; an explicit non-true value
+// (e.g. `?bridge-only=false`) or the param being absent leave it disabled.
 const BRIDGE_ONLY_PARAM = 'bridge-only'
 
-const isBridgeOnlyEnabled = (searchParams: URLSearchParams): boolean => (searchParams.get(BRIDGE_ONLY_PARAM) ?? '').toLowerCase() === 'true'
+const isBridgeOnlyEnabled = (searchParams: URLSearchParams): boolean => {
+  if (!searchParams.has(BRIDGE_ONLY_PARAM)) {
+    return false
+  }
+  const value = (searchParams.get(BRIDGE_ONLY_PARAM) ?? '').toLowerCase()
+  return value === '' || value === 'true'
+}
 
 export type { LoginMethod }
 export { locations, extractRedirectToFromSearchParameters, extractReferrerFromSearchParameters, isBridgeOnlyEnabled, BRIDGE_ONLY_PARAM }

--- a/src/shared/locations.ts
+++ b/src/shared/locations.ts
@@ -148,5 +148,13 @@ const extractReferrerFromSearchParameters = (searchParams: URLSearchParams): str
   return referrerSearchParam
 }
 
+// The `bridge-only` query param is a boolean flag the auth site can be opened with.
+// It's preserved across logins/callbacks by riding inside `redirectTo`, and when enabled
+// it's forwarded onto the client deep link. Only a truthy value ("true", case-insensitive)
+// enables it — "false" or an empty value are treated as not set.
+const BRIDGE_ONLY_PARAM = 'bridge-only'
+
+const isBridgeOnlyEnabled = (searchParams: URLSearchParams): boolean => (searchParams.get(BRIDGE_ONLY_PARAM) ?? '').toLowerCase() === 'true'
+
 export type { LoginMethod }
-export { locations, extractRedirectToFromSearchParameters, extractReferrerFromSearchParameters }
+export { locations, extractRedirectToFromSearchParameters, extractReferrerFromSearchParameters, isBridgeOnlyEnabled, BRIDGE_ONLY_PARAM }


### PR DESCRIPTION
## What

Adds support for a `bridge-only` query parameter on the auth site. When set, the flag is **preserved across logins and OAuth callbacks** and appended to the client **deep link** that opens the app.

## Why

The client needs to know when a session was initiated in "bridge-only" mode so it can behave accordingly once opened via the deep link. The flag has to survive the full auth flow (wallet/social login + Magic OAuth round-trip) and end up on the generated deep link.

## How it works

- The flag rides **inside `redirectTo`**, so it automatically survives internal navigation and the Magic social-login round-trip (stored in `customData`, reconstructed on `/auth/callback`) — no new OAuth state plumbing needed.
- `RequestPage` reads it once via a small `isBridgeOnlyEnabled(searchParams)` helper and appends the canonical `bridge-only=true` to **every** desktop deep-link generation site:
  - the `flow=deeplink` "Continue in app" link (`decentraland://open?signin=…&bridge-only=true`)
  - the Explorer completion link via `getExplorerDeeplink` (`…?dclenv=zone&bridge-only=true`)
  - the `RecoverError` retry redirect
  - the traditional-flow bare redirect (`window.location.href = targetConfig.deepLink`) — previously this bypassed `getExplorerDeeplink` and emitted a **completely bare** scheme, so it now also **restores the long-missing `dclenv`** for schemes like `dcl-creator-hub://`.
- The "use another profile" (change-account) link preserves the flag too.

## Value semantics

A **bare flag** (`?bridge-only`) or an explicit `?bridge-only=true` (case-insensitive) enable it. An explicit non-true value (`?bridge-only=false`) or the param being absent leave it disabled. The raw value is **never re-emitted** — only the fixed literal `bridge-only=true` is written, so there's no injection surface.

## Scope

Desktop flows only (deep-link + Explorer completion). The `/mobile` flow is intentionally untouched — its deep link hardcodes `decentraland://open?signin=…` and would need `bridge-only` threaded through the OAuth `customData`, which can be a follow-up if needed.

## Tests

- `isBridgeOnlyEnabled`: `true` / `TRUE` / bare `?bridge-only` / empty value → enabled; `false` / `1` / absent → disabled.
- `getExplorerDeeplink`: prod / development / named-env × bridge-only on/off, including param ordering (`dclenv` then `bridge-only`) and the no-deep-link fallback.
- Updated the `shared/locations` mock in `RequestPage.spec.tsx`.
- Full `jest` suite green, `tsc --noEmit` clean, `eslint` clean.
