### PR TITLE
fix: address security-review findings across request, redirect and auth flows

### DIFF
--- a/src/components/Pages/AvatarSetupPage/AvatarSetupPage.tsx
+++ b/src/components/Pages/AvatarSetupPage/AvatarSetupPage.tsx
@@ -218,6 +218,17 @@ const AvatarSetupPage: React.FC = () => {
 
   const handleMessage = useCallback(
     async (event: MessageEvent) => {
+      // Only trust messages coming from the WearablePreview iframe. Without this check any
+      // page holding a handle to this window (popup/iframe) could post a forged
+      // `customization-done` payload and deploy an attacker-chosen profile with the user's identity.
+      let previewOrigin: string
+      try {
+        previewOrigin = new URL(config.get('WEARABLE_PREVIEW_URL')).origin
+      } catch {
+        return
+      }
+      if (event.origin !== previewOrigin) return
+
       if (event.data.type !== 'controller_response') return
 
       if (event.data.payload.id === 'avatar-customization-step') {

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -4,7 +4,7 @@ import { createPublicClient, createWalletClient, custom, formatEther } from 'vie
 import { mainnet } from 'viem/chains'
 import { useTranslation } from '@dcl/hooks'
 import { ContractName, getContract, sendMetaTransaction } from 'decentraland-transactions'
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from 'decentraland-ui2'
+import { Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle } from 'decentraland-ui2'
 import { useNavigateWithSearchParams } from '../../../hooks/navigation'
 import { useTargetConfig } from '../../../hooks/targetConfig'
 import { useAnalytics } from '../../../hooks/useAnalytics'
@@ -96,11 +96,12 @@ interface TransactionConfirmDialogProps {
   open: boolean
   transactionCost: bigint
   balance: bigint
+  isLoading?: boolean
   onCancel: () => void
   onConfirm: () => void
 }
 
-const TransactionConfirmDialog = ({ open, transactionCost, balance, onCancel, onConfirm }: TransactionConfirmDialogProps) => {
+const TransactionConfirmDialog = ({ open, transactionCost, balance, isLoading, onCancel, onConfirm }: TransactionConfirmDialogProps) => {
   const { t } = useTranslation()
   return (
     <Dialog open={open} maxWidth="xs" fullWidth>
@@ -110,9 +111,11 @@ const TransactionConfirmDialog = ({ open, transactionCost, balance, onCancel, on
         <p>{t('request.transaction_dialog.your_balance', { balance: formatEther(balance) })}</p>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel}>{t('common.cancel')}</Button>
-        <Button variant="contained" onClick={onConfirm}>
-          {t('common.confirm')}
+        <Button onClick={onCancel} disabled={isLoading}>
+          {t('common.cancel')}
+        </Button>
+        <Button variant="contained" onClick={onConfirm} disabled={isLoading}>
+          {isLoading ? <CircularProgress size={20} color="inherit" /> : t('common.confirm')}
         </Button>
       </DialogActions>
     </Dialog>
@@ -164,6 +167,9 @@ export const RequestPage = () => {
   const viewRef = useRef(view)
   viewRef.current = view
   const hasCompletedRef = useRef(false)
+  // Guards against re-entrant approvals (e.g. a fast double-click on the confirm dialog),
+  // which would otherwise fire two transactions before `isLoading` re-renders the buttons.
+  const isApprovingRef = useRef(false)
   // Ref to read the latest identity inside the effect without adding it as a dependency.
   // Only used in the profile-check effect (profile redeployment). Callbacks like
   // onApproveSignInVerification close over `identity` directly so they stay consistent
@@ -302,17 +308,19 @@ export const RequestPage = () => {
         requestRef.current = request
 
         // Initialize the timeout to display the timeout view when the request expires.
-        timeoutRef.current = setTimeout(
-          () => {
+        // Guard against an unparseable expiration: `new Date(...).getTime()` would be NaN,
+        // which setTimeout coerces to 0 and fires the timeout view immediately.
+        const expirationDelay = new Date(request.expiration).getTime() - Date.now()
+        if (!Number.isNaN(expirationDelay)) {
+          timeoutRef.current = setTimeout(() => {
             getAnalytics()?.track(TrackingEvents.REQUEST_EXPIRED, {
               browserTime: Date.now(),
               requestTime: new Date(request.expiration).getTime(),
               timeTheSiteStartedLoading
             })
             setView(View.TIMEOUT)
-          },
-          new Date(request.expiration).getTime() - Date.now()
-        )
+          }, expirationDelay)
+        }
 
         // Show different views depending on the request method.
         switch (request.method) {
@@ -385,7 +393,7 @@ export const RequestPage = () => {
               const transactionData = txParams?.data as string | undefined
               const contractAddress = txParams?.to as string | undefined
               if (transactionData && contractAddress) {
-                const manaData = decodeManaTransferData(transactionData)
+                const manaData = decodeManaTransferData(transactionData, contractAddress)
                 if (manaData) {
                   const [recipientProfile, placeInfo] = await Promise.all([
                     fetchProfile(manaData.toAddress),
@@ -395,7 +403,9 @@ export const RequestPage = () => {
                   if (cancelled) return
 
                   setManaTransferData({
-                    manaAmount: `${parseInt(manaData.manaAmount, 10)} MANA`,
+                    // Show the exact formatted amount (formatEther already trims trailing zeros).
+                    // parseInt truncated fractional MANA, under-displaying what is actually signed.
+                    manaAmount: `${manaData.manaAmount} MANA`,
                     toAddress: manaData.toAddress,
                     recipientProfile: recipientProfile || undefined,
                     sceneName: placeInfo?.sceneName || 'Unknown Place',
@@ -647,6 +657,10 @@ export const RequestPage = () => {
   }, [nftTransferData, manaTransferData, requestId])
 
   const onApproveWalletInteraction = useCallback(async () => {
+    // Prevent duplicate submissions — the confirm dialog buttons aren't disabled synchronously,
+    // so a double-click could otherwise re-enter before the first call flips isLoading.
+    if (isApprovingRef.current) return
+    isApprovingRef.current = true
     setIsLoading(true)
     setIsTransactionModalOpen(false)
     const walletClient = walletClientRef.current
@@ -766,6 +780,7 @@ export const RequestPage = () => {
       }
     } finally {
       setIsLoading(false)
+      isApprovingRef.current = false
     }
   }, [isUserUsingWeb2Wallet, nftTransferData, manaTransferData, requestId, identity])
 
@@ -859,6 +874,7 @@ export const RequestPage = () => {
             open={isTransactionModalOpen}
             transactionCost={transactionGasCost ?? BigInt(0)}
             balance={walletInfo?.balance ?? BigInt(0)}
+            isLoading={isLoading}
             onCancel={onDenyWalletInteraction}
             onConfirm={onApproveWalletInteraction}
           />
@@ -878,6 +894,7 @@ export const RequestPage = () => {
             open={isTransactionModalOpen}
             transactionCost={transactionGasCost ?? BigInt(0)}
             balance={walletInfo?.balance ?? BigInt(0)}
+            isLoading={isLoading}
             onCancel={onDenyWalletInteraction}
             onConfirm={onApproveWalletInteraction}
           />
@@ -897,6 +914,7 @@ export const RequestPage = () => {
             open={isTransactionModalOpen}
             transactionCost={transactionGasCost ?? BigInt(0)}
             balance={walletInfo?.balance ?? BigInt(0)}
+            isLoading={isLoading}
             onCancel={onDenyWalletInteraction}
             onConfirm={onApproveWalletInteraction}
           />

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -310,6 +310,8 @@ export const RequestPage = () => {
         // Initialize the timeout to display the timeout view when the request expires.
         // Guard against an unparseable expiration: `new Date(...).getTime()` would be NaN,
         // which setTimeout coerces to 0 and fires the timeout view immediately.
+        // A negative delay (a request that is already past its expiration) is intentional:
+        // setTimeout coerces it to 0 so the timeout view shows right away.
         const expirationDelay = new Date(request.expiration).getTime() - Date.now()
         if (!Number.isNaN(expirationDelay)) {
           timeoutRef.current = setTimeout(() => {

--- a/src/components/Pages/RequestPage/utils.spec.ts
+++ b/src/components/Pages/RequestPage/utils.spec.ts
@@ -395,12 +395,15 @@ describe('when testing decodeNftTransferData', () => {
 
 describe('when testing decodeManaTransferData', () => {
   let transactionData: string
+  let manaContractAddress: string
   let mockContract: any
 
   beforeEach(() => {
     jest.mocked(config.get).mockReturnValue('production')
+    manaContractAddress = '0x0f5d2fb29fb7d3cfee444a200298f468908cc942'
     mockContract = {
-      abi: [{ type: 'function', name: 'transfer' }]
+      abi: [{ type: 'function', name: 'transfer' }],
+      address: manaContractAddress
     }
     jest.mocked(getContract).mockReturnValue(mockContract)
   })
@@ -409,7 +412,7 @@ describe('when testing decodeManaTransferData', () => {
     jest.resetAllMocks()
   })
 
-  describe('and the transaction data is a valid ERC20 transfer', () => {
+  describe('and the transaction data is a valid MANA transfer', () => {
     beforeEach(() => {
       transactionData =
         '0xa9059cbb000000000000000000000000abcdef1234567890abcdef1234567890abcdef12000000000000000000000000000000000000000000000000016345785d8a0000'
@@ -421,11 +424,55 @@ describe('when testing decodeManaTransferData', () => {
     })
 
     it('should return the manaAmount and toAddress', () => {
-      const result = decodeManaTransferData(transactionData)
+      const result = decodeManaTransferData(transactionData, manaContractAddress)
       expect(result).toEqual({
         manaAmount: '0.1',
         toAddress: '0xabcdef1234567890abcdef1234567890abcdef12'
       })
+    })
+  })
+
+  describe('and the transaction targets the MANA contract with a differently-cased address', () => {
+    beforeEach(() => {
+      transactionData =
+        '0xa9059cbb000000000000000000000000abcdef1234567890abcdef1234567890abcdef12000000000000000000000000000000000000000000000000016345785d8a0000'
+      jest.mocked(decodeFunctionData).mockReturnValueOnce({
+        functionName: 'transfer',
+        args: ['0xabcdef1234567890abcdef1234567890abcdef12', BigInt('100000000000000000')]
+      })
+      jest.mocked(formatEther).mockReturnValueOnce('0.1')
+    })
+
+    it('should decode the transfer regardless of address casing', () => {
+      const result = decodeManaTransferData(transactionData, manaContractAddress.toUpperCase())
+      expect(result).toEqual({
+        manaAmount: '0.1',
+        toAddress: '0xabcdef1234567890abcdef1234567890abcdef12'
+      })
+    })
+  })
+
+  describe('and the transaction targets a non-MANA token contract', () => {
+    beforeEach(() => {
+      transactionData =
+        '0xa9059cbb000000000000000000000000abcdef1234567890abcdef1234567890abcdef12000000000000000000000000000000000000000000000000016345785d8a0000'
+    })
+
+    it('should return null without decoding the transfer', () => {
+      const result = decodeManaTransferData(transactionData, '0x1111111111111111111111111111111111111111')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('and the contract address is empty', () => {
+    beforeEach(() => {
+      transactionData =
+        '0xa9059cbb000000000000000000000000abcdef1234567890abcdef1234567890abcdef12000000000000000000000000000000000000000000000000016345785d8a0000'
+    })
+
+    it('should return null', () => {
+      const result = decodeManaTransferData(transactionData, '')
+      expect(result).toBeNull()
     })
   })
 
@@ -435,7 +482,7 @@ describe('when testing decodeManaTransferData', () => {
     })
 
     it('should return null', () => {
-      const result = decodeManaTransferData(transactionData)
+      const result = decodeManaTransferData(transactionData, manaContractAddress)
       expect(result).toBeNull()
     })
   })
@@ -446,7 +493,7 @@ describe('when testing decodeManaTransferData', () => {
     })
 
     it('should return null', () => {
-      const result = decodeManaTransferData(transactionData)
+      const result = decodeManaTransferData(transactionData, manaContractAddress)
       expect(result).toBeNull()
     })
   })
@@ -457,7 +504,7 @@ describe('when testing decodeManaTransferData', () => {
     })
 
     it('should return null', () => {
-      const result = decodeManaTransferData(transactionData)
+      const result = decodeManaTransferData(transactionData, manaContractAddress)
       expect(result).toBeNull()
     })
   })
@@ -472,7 +519,7 @@ describe('when testing decodeManaTransferData', () => {
     })
 
     it('should return null', () => {
-      const result = decodeManaTransferData(transactionData)
+      const result = decodeManaTransferData(transactionData, manaContractAddress)
       expect(result).toBeNull()
     })
   })
@@ -486,7 +533,7 @@ describe('when testing decodeManaTransferData', () => {
     })
 
     it('should return null', () => {
-      const result = decodeManaTransferData(transactionData)
+      const result = decodeManaTransferData(transactionData, manaContractAddress)
       expect(result).toBeNull()
     })
   })
@@ -503,7 +550,7 @@ describe('when testing decodeManaTransferData', () => {
     })
 
     it('should correctly convert large amounts from wei to MANA', () => {
-      const result = decodeManaTransferData(transactionData)
+      const result = decodeManaTransferData(transactionData, manaContractAddress)
       expect(result).toEqual({
         manaAmount: '1000.0',
         toAddress: '0xabcdef1234567890abcdef1234567890abcdef12'
@@ -709,6 +756,21 @@ describe('when testing fetchNftMetadata', () => {
       await expect(fetchNftMetadata(contractAddress, contractABI, tokenId)).rejects.toThrow(
         `Failed to fetch metadata from ${tokenUri}: 404 Not Found`
       )
+    })
+  })
+
+  describe('and the tokenURI uses a non-http scheme', () => {
+    beforeEach(() => {
+      mockPublicClient = {
+        getChainId: jest.fn().mockResolvedValue(1),
+        readContract: jest.fn().mockResolvedValueOnce('javascript:alert(1)')
+      }
+      jest.mocked(createPublicClient).mockReturnValue(mockPublicClient)
+    })
+
+    it('should throw an unsupported-scheme error without fetching', async () => {
+      await expect(fetchNftMetadata(contractAddress, contractABI, tokenId)).rejects.toThrow('Unsupported tokenURI scheme')
+      expect(fetch).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/components/Pages/RequestPage/utils.spec.ts
+++ b/src/components/Pages/RequestPage/utils.spec.ts
@@ -773,4 +773,32 @@ describe('when testing fetchNftMetadata', () => {
       expect(fetch).not.toHaveBeenCalled()
     })
   })
+
+  describe('and the metadata image uses a non-http scheme', () => {
+    let tokenUri: string
+    let metadata: any
+
+    beforeEach(() => {
+      tokenUri = 'https://example.com/token/123'
+      metadata = {
+        name: 'Test NFT',
+        description: 'A test NFT',
+        image: 'data:image/svg+xml,<svg onload="alert(1)"></svg>'
+      }
+      mockPublicClient = {
+        getChainId: jest.fn().mockResolvedValue(1),
+        readContract: jest.fn().mockResolvedValueOnce(tokenUri)
+      }
+      jest.mocked(createPublicClient).mockReturnValue(mockPublicClient)
+      jest.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(metadata)
+      } as any)
+    })
+
+    it('should drop the image URL and return an empty imageUrl', async () => {
+      const result = await fetchNftMetadata(contractAddress, contractABI, tokenId)
+      expect(result.imageUrl).toBe('')
+    })
+  })
 })

--- a/src/components/Pages/RequestPage/utils.ts
+++ b/src/components/Pages/RequestPage/utils.ts
@@ -160,19 +160,31 @@ function decodeNftTransferData(data: string, contractABI: object[]): { tokenId: 
 }
 
 /**
- * Decodes MANA (ERC20) transfer data to extract amount and destination address
+ * Decodes MANA (ERC20) transfer data to extract amount and destination address.
+ * Only decodes when the transaction targets the canonical MANA token contract, so an
+ * arbitrary ERC20 transfer can't be presented to the user as a MANA tip.
  * @param data The transaction data
+ * @param contractAddress The transaction `to` address (the token contract being called)
  * @returns Object containing manaAmount and toAddress, or null if decoding fails
  */
-function decodeManaTransferData(data: string): { manaAmount: string; toAddress: string } | null {
+function decodeManaTransferData(data: string, contractAddress: string): { manaAmount: string; toAddress: string } | null {
   try {
     if (!data || data.length < 10) return null
+    if (!contractAddress) return null
 
     // ERC20 transfer function signature: transfer(address to, uint256 amount)
     const transferFunctionSignature = '0xa9059cbb'
 
     // Check if this is a transfer function call
     if (!data.startsWith(transferFunctionSignature)) {
+      return null
+    }
+
+    // Only treat this as a MANA transfer if it targets the canonical MANA token contract.
+    // Without this, any ERC20 transfer (`transfer(to, amount)`) would be mislabeled as MANA
+    // and its amount mis-formatted (formatEther assumes 18 decimals).
+    const manaContract = getContract(ContractName.MANAToken, getMetaTransactionChainId())
+    if (contractAddress.toLowerCase() !== manaContract.address.toLowerCase()) {
       return null
     }
 
@@ -232,8 +244,19 @@ async function fetchNftMetadata(
     throw new Error(`No tokenURI returned for token ${tokenId} at contract ${contractAddress}`)
   }
 
-  // Handle IPFS URIs
+  // The tokenURI comes from an arbitrary (attacker-chosen) contract, so only allow http(s)
+  // before fetching. This blocks schemes like javascript:/data:/file: from being passed to fetch.
   const metadataUrl = tokenUri
+
+  let metadataProtocol: string
+  try {
+    metadataProtocol = new URL(metadataUrl).protocol
+  } catch {
+    throw new Error(`Invalid tokenURI for token ${tokenId} at contract ${contractAddress}`)
+  }
+  if (metadataProtocol !== 'https:' && metadataProtocol !== 'http:') {
+    throw new Error(`Unsupported tokenURI scheme "${metadataProtocol}" for token ${tokenId} at contract ${contractAddress}`)
+  }
 
   // Fetch the metadata JSON
   const metadataResponse = await fetch(metadataUrl)

--- a/src/components/Pages/RequestPage/utils.ts
+++ b/src/components/Pages/RequestPage/utils.ts
@@ -266,7 +266,22 @@ async function fetchNftMetadata(
 
   const metadata = await metadataResponse.json()
 
-  const imageUrl = metadata.image || metadata.image_url
+  // The metadata comes from an attacker-controllable contract/URL, so only surface http(s)
+  // image URLs. This drops data:/other-scheme values as defense-in-depth (the actual transfer
+  // token/recipient come from the decoded tx, not this cosmetic field); a dropped image just
+  // falls back to the view's placeholder rather than breaking it.
+  const rawImageUrl = metadata.image || metadata.image_url
+  let imageUrl = ''
+  if (typeof rawImageUrl === 'string') {
+    try {
+      const imageProtocol = new URL(rawImageUrl).protocol
+      if (imageProtocol === 'https:' || imageProtocol === 'http:') {
+        imageUrl = rawImageUrl
+      }
+    } catch {
+      // Ignore malformed image URLs — leave imageUrl empty.
+    }
+  }
 
   // Extract rarity from attributes
   let rarity: Rarity = Rarity.COMMON

--- a/src/hooks/targetConfig.spec.ts
+++ b/src/hooks/targetConfig.spec.ts
@@ -141,6 +141,21 @@ describe('useTargetConfig', () => {
     })
   })
 
+  describe('when the targetConfigId is an inherited Object.prototype key', () => {
+    beforeEach(() => {
+      ;(useLocation as jest.Mock).mockReturnValue({ search: '?targetConfigId=constructor' })
+      ;(isMobile as jest.Mock).mockReturnValue(false)
+    })
+
+    it('should return the default config instead of a prototype value', () => {
+      const { result } = renderHook(() => useTargetConfig())
+      const [config, targetConfigId] = result.current
+
+      expect(targetConfigId).toBe('default')
+      expect(config).toEqual(_targetConfigs.default)
+    })
+  })
+
   describe('when on iOS mobile with no targetConfigId', () => {
     beforeEach(() => {
       ;(useLocation as jest.Mock).mockReturnValue({ search: '' })

--- a/src/hooks/targetConfig.ts
+++ b/src/hooks/targetConfig.ts
@@ -105,8 +105,10 @@ const getTargetConfigId = (location: Location): TargetConfigId => {
   const targetConfigIdParam = search.get('targetConfigId') as TargetConfigId
   const redirectTo = extractRedirectToFromSearchParameters(search)
 
-  // If explicit targetConfigId is provided, use it
-  if (targetConfigIdParam in targetConfigs) {
+  // If explicit targetConfigId is provided, use it. Use hasOwnProperty rather than `in`
+  // so inherited Object.prototype keys (e.g. ?targetConfigId=constructor) can't select a
+  // non-config value.
+  if (Object.prototype.hasOwnProperty.call(targetConfigs, targetConfigIdParam)) {
     return targetConfigIdParam
   }
 
@@ -121,7 +123,7 @@ const getTargetConfigId = (location: Location): TargetConfigId => {
         searchParams = new URL(redirectTo).searchParams
       }
       const targetConfigIdFromRedirectTo = searchParams.get('targetConfigId') as TargetConfigId
-      if (targetConfigIdFromRedirectTo in targetConfigs) {
+      if (Object.prototype.hasOwnProperty.call(targetConfigs, targetConfigIdFromRedirectTo)) {
         return targetConfigIdFromRedirectTo
       }
     } catch {

--- a/src/hooks/useDisabledCatalysts.ts
+++ b/src/hooks/useDisabledCatalysts.ts
@@ -20,7 +20,10 @@ export const useDisabledCatalysts = (): string[] => {
     }
 
     try {
-      return JSON.parse(payloadValue)
+      const parsed = JSON.parse(payloadValue)
+      // The payload comes from remote feature-flag config; only trust it if it's actually
+      // an array of catalyst addresses, otherwise downstream `.includes`/spread would throw.
+      return Array.isArray(parsed) ? parsed : EMPTY_LIST
     } catch {
       return EMPTY_LIST
     }

--- a/src/hooks/useTrackReferral.ts
+++ b/src/hooks/useTrackReferral.ts
@@ -21,7 +21,8 @@ export const useTrackReferral = () => {
         await fetch(`${REFERRAL_SERVER_URL}/referral-progress`, {
           method,
           headers: {
-            contentType: 'application/json'
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            'Content-Type': 'application/json'
           },
           ...(body && { body }),
           identity

--- a/src/modules/analytics/sentry.ts
+++ b/src/modules/analytics/sentry.ts
@@ -10,7 +10,9 @@ init({
   environment: config.get('ENVIRONMENT'),
   release: `${config.get('SENTRY_RELEASE_PREFIX', 'auth')}@${import.meta.env.VITE_REACT_APP_WEBSITE_VERSION}`,
   dsn,
-  integrations: [browserTracingIntegration(), replayIntegration()],
+  // Explicitly mask all text and media in Session Replay. This surface renders email/OTP
+  // inputs and sign-in verification codes, so we never want replays to capture their values.
+  integrations: [browserTracingIntegration(), replayIntegration({ maskAllText: true, blockAllMedia: true })],
   // Performance Monitoring
   tracesSampleRate: 0.001,
   // Session Replay

--- a/src/shared/auth/httpClient.ts
+++ b/src/shared/auth/httpClient.ts
@@ -136,7 +136,7 @@ export const createAuthServerHttpClient = (authServerUrl?: string) => {
         await extractError(response, requestId)
       }
 
-      const recoverResponse = await response.json()
+      recoverResponse = (await response.json()) as RecoverResponse
 
       // If the sender defined in the request is different than the one that is connected, show an error.
       if (recoverResponse.sender && recoverResponse.sender !== signerAddress.toLowerCase()) {

--- a/src/shared/auth/wsClient.spec.ts
+++ b/src/shared/auth/wsClient.spec.ts
@@ -26,8 +26,10 @@ describe('createAuthServerClient', () => {
   const mockEmitWithAck = jest.fn()
   const mockClose = jest.fn()
   const mockOn = jest.fn()
+  const mockOff = jest.fn()
   const mockSocket = {
     on: mockOn,
+    off: mockOff,
     emitWithAck: mockEmitWithAck,
     close: mockClose
   }
@@ -175,6 +177,57 @@ describe('createAuthServerClient', () => {
       it('should close the socket', async () => {
         await expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toThrow('Connection refused')
         expect(mockClose).toHaveBeenCalled()
+      })
+    })
+
+    describe('when the socket never connects', () => {
+      beforeEach(() => {
+        jest.useFakeTimers()
+        mockOn.mockReset()
+        // Never fire connect or connect_error so the connection promise stays pending.
+        mockOn.mockImplementation(() => undefined)
+      })
+
+      afterEach(() => {
+        jest.useRealTimers()
+      })
+
+      it('should reject with a connection timeout after CONNECT_TIMEOUT_MS', async () => {
+        const assertion = expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toThrow(
+          'Timed out connecting to the auth server'
+        )
+        await jest.advanceTimersByTimeAsync(15000)
+        await assertion
+      })
+
+      it('should close the socket after the connection times out', async () => {
+        const assertion = expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toThrow(
+          'Timed out connecting to the auth server'
+        )
+        await jest.advanceTimersByTimeAsync(15000)
+        await assertion
+        expect(mockClose).toHaveBeenCalled()
+      })
+    })
+
+    describe('when the server never acknowledges the request', () => {
+      beforeEach(() => {
+        jest.useFakeTimers()
+        mockEmitWithAck.mockReset()
+        // Connect succeeds (via the default mockOn), but the ack never resolves.
+        mockEmitWithAck.mockReturnValue(new Promise(() => undefined))
+      })
+
+      afterEach(() => {
+        jest.useRealTimers()
+      })
+
+      it('should reject with an ack timeout after ACK_TIMEOUT_MS', async () => {
+        const assertion = expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toThrow(
+          'Timed out waiting for the auth server response'
+        )
+        await jest.advanceTimersByTimeAsync(30000)
+        await assertion
       })
     })
   })

--- a/src/shared/auth/wsClient.spec.ts
+++ b/src/shared/auth/wsClient.spec.ts
@@ -157,6 +157,26 @@ describe('createAuthServerClient', () => {
         await expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toBeInstanceOf(ImpersonatedSignInError)
       })
     })
+
+    describe('when the socket connection fails', () => {
+      beforeEach(() => {
+        mockOn.mockReset()
+        mockOn.mockImplementation((event, callback) => {
+          if (event === 'connect_error') {
+            callback(new Error('Connection refused'))
+          }
+        })
+      })
+
+      it('should reject with the connection error instead of hanging', async () => {
+        await expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toThrow('Connection refused')
+      })
+
+      it('should close the socket', async () => {
+        await expect(client.recover(mockRequestId, mockSignerAddress)).rejects.toThrow('Connection refused')
+        expect(mockClose).toHaveBeenCalled()
+      })
+    })
   })
 
   describe('when sending a successful outcome', () => {

--- a/src/shared/auth/wsClient.ts
+++ b/src/shared/auth/wsClient.ts
@@ -39,7 +39,12 @@ export const createAuthServerWsClient = (authServerUrl?: string) => {
       // Reject (rather than hang) if the connection can't be established or times out.
       await withTimeout(
         new Promise<void>((resolve, reject) => {
-          socket.on('connect', resolve)
+          socket.on('connect', () => {
+            // Detach the error handler once connected so a later reconnection error
+            // (before socket.close) can't call reject on an already-settled promise.
+            socket.off('connect_error', reject)
+            resolve()
+          })
           socket.on('connect_error', reject)
         }),
         CONNECT_TIMEOUT_MS,

--- a/src/shared/auth/wsClient.ts
+++ b/src/shared/auth/wsClient.ts
@@ -7,6 +7,25 @@ import { DifferentSenderError, ExpiredRequestError, IpValidationError, RequestFu
 import { assertRequestIsNotImpersonatingSignIn } from './signMethodGuard'
 import { OutcomeError, OutcomeResponse, RecoverResponse, ValidationResponse } from './types'
 
+// Fail fast instead of hanging forever if the auth server is unreachable or never acks.
+const CONNECT_TIMEOUT_MS = 15000
+const ACK_TIMEOUT_MS = 30000
+
+const withTimeout = <T>(promise: Promise<T>, ms: number, message: string): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms)
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      error => {
+        clearTimeout(timer)
+        reject(error)
+      }
+    )
+  })
+
 export const createAuthServerWsClient = (authServerUrl?: string) => {
   const url = authServerUrl ?? config.get('AUTH_SERVER_URL')
 
@@ -16,15 +35,31 @@ export const createAuthServerWsClient = (authServerUrl?: string) => {
   ): Promise<T> => {
     const socket = io(url)
 
-    await new Promise<void>(resolve => {
-      socket.on('connect', resolve)
-    })
+    try {
+      // Reject (rather than hang) if the connection can't be established or times out.
+      await withTimeout(
+        new Promise<void>((resolve, reject) => {
+          socket.on('connect', resolve)
+          socket.on('connect_error', reject)
+        }),
+        CONNECT_TIMEOUT_MS,
+        'Timed out connecting to the auth server'
+      )
 
-    const response = await socket.emitWithAck(event, message)
+      const response = await withTimeout(
+        socket.emitWithAck(event, message),
+        ACK_TIMEOUT_MS,
+        'Timed out waiting for the auth server response'
+      )
 
-    // Close client, we don't need it anymore
-    socket.close()
+      return handleResponse<T>(response, message)
+    } finally {
+      // Always close the socket, including on connect/ack timeouts and errors.
+      socket.close()
+    }
+  }
 
+  const handleResponse = <T>(response: { error?: string } & T, message: { requestId: string }): T => {
     if (response.error?.includes('already been fulfilled')) {
       throw new RequestFulfilledError(message.requestId)
     } else if (response.error?.includes('not found')) {

--- a/vercel.json
+++ b/vercel.json
@@ -16,5 +16,16 @@
       "destination": "/auth"
     }
   ],
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Content-Security-Policy", "value": "frame-ancestors 'none'" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## What

Addresses a set of security and correctness findings from a code review of the auth site. All changes are self-contained; no behavior change for legitimate flows.

### Security

- **MANA transfer spoofing** — an `eth_sendTransaction` is now decoded as a MANA transfer only when it targets the canonical `MANAToken` contract for the chain (case-insensitive). Arbitrary ERC20 `transfer(...)` calls can no longer be presented to the user as a MANA tip.
- **Message origin validation** — `AvatarSetupPage`'s `message` handler now verifies `event.origin` against the WearablePreview URL before acting on `controller_response` payloads, so a foreign window (popup/iframe) can no longer drive a profile deploy.
- **Anti-clickjacking headers** — added `X-Frame-Options: DENY`, `Content-Security-Policy: frame-ancestors 'none'`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy` to `vercel.json`. Note: production is CDN-served, so the same headers should also be applied at the edge — `vercel.json` only covers Vercel deploys.
- **`targetConfigId` prototype keys** — resolve the config with `hasOwnProperty` instead of `in`, so `?targetConfigId=constructor` (and other inherited keys) fall back to `default` instead of selecting a non-config value.
- **NFT `tokenURI` fetching** — reject non-`http(s)` schemes before `fetch`, since the URI comes from an arbitrary contract.
- **Sentry Session Replay** — explicitly set `maskAllText`/`blockAllMedia` given the page renders email/OTP inputs.

### Correctness

- **Referral `Content-Type`** — was `contentType` (a no-op key), which left the header unset and could drop referral attribution when the server requires `application/json`.
- **Double-submit guard** — the transaction confirm dialog now has a re-entrancy ref plus disabled buttons while loading, preventing a fast double-click from firing two transactions.
- **Auth WS client** — added `connect_error` handling and connect/ack timeouts (and always close the socket), so calls fail fast instead of hanging indefinitely when the server is unreachable.
- **`DISABLED_CATALYSTS` flag** — validate the parsed feature-flag payload is an array before use, so a malformed remote value can't break profile checks/deploys.
- **MANA amount display** — show the exact `formatEther` amount instead of truncating fractional MANA with `parseInt`.
- **Recover-error telemetry** — fixed a shadowed `recoverResponse` in the HTTP auth client so error tracking reports the real request method instead of `Unknown`.
- **Expiration timeout** — guard against an unparseable `expiration` (which would otherwise coerce to `0` and fire the timeout view immediately).

## Testing

- `tsc --noEmit`: clean
- Full Jest suite: **95 suites / 1510 tests passing**
- Added/updated unit tests for the MANA contract check, `targetConfigId` prototype-key handling, the WS connect-error path, and the NFT URI scheme handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
