### PR TITLE
feat: change wallet from client-login view and shrink avatar preview

### DIFF
--- a/src/components/CustomWearablePreview/CustomWearablePreview.css
+++ b/src/components/CustomWearablePreview/CustomWearablePreview.css
@@ -9,7 +9,7 @@
 }
 
 /* Overlay the loading spinner on the center of the preview instead of letting it sit in
-   normal flow (which pushes it off-center, more noticeable now the preview is smaller). */
+   normal flow, which pushes it off-center. */
 .CustomWearablePreview .MuiCircularProgress-root {
   position: absolute;
   top: 50%;

--- a/src/components/CustomWearablePreview/CustomWearablePreview.css
+++ b/src/components/CustomWearablePreview/CustomWearablePreview.css
@@ -7,3 +7,12 @@
 .CustomWearablePreview .WearablePreview {
   background-color: unset;
 }
+
+/* Overlay the loading spinner on the center of the preview instead of letting it sit in
+   normal flow (which pushes it off-center, more noticeable now the preview is smaller). */
+.CustomWearablePreview .MuiCircularProgress-root {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}

--- a/src/components/Pages/LoginPage/LoginPage.styled.ts
+++ b/src/components/Pages/LoginPage/LoginPage.styled.ts
@@ -16,7 +16,10 @@ const Main = styled('main')(({ theme }) => ({
   width: '100%',
   maxWidth: '100vw',
   position: 'relative',
-  overflow: 'hidden',
+  // Keep the animated background from causing horizontal scroll, but let the box scroll
+  // vertically so short viewports can reach the bottom of the form instead of clipping it.
+  overflowX: 'hidden',
+  overflowY: 'auto',
   minWidth: 0,
   boxSizing: 'border-box',
   ['&::before']: {

--- a/src/components/Pages/RequestPage/Container/Container.module.css
+++ b/src/components/Pages/RequestPage/Container/Container.module.css
@@ -28,9 +28,9 @@
   right: 8%;
 }
 
-/* The preview auto-fits the avatar to fill its box, so shrinking the box just shrinks the
-   whole panel. Keep the box full-size and scale the rendered avatar to half instead. */
-.right :global(.CustomWearablePreview .WearablePreview) {
+/* Scale the rendered avatar to half. Target the iframe directly: WearablePreview renders a
+   bare styled iframe with an emotion-generated class, so there is no .WearablePreview hook. */
+.right :global(.CustomWearablePreview iframe) {
   transform: scale(0.5);
 }
 

--- a/src/components/Pages/RequestPage/Container/Container.module.css
+++ b/src/components/Pages/RequestPage/Container/Container.module.css
@@ -22,16 +22,16 @@
 
 .right {
   height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
-/* Half the previous size (was 100% x 100% of the right column): the fixed-camera
-   preview scales with its container, so the avatar renders half as big. */
 .right :global(.CustomWearablePreview) {
-  width: 50%;
-  height: 50%;
+  right: 8%;
+}
+
+/* The preview auto-fits the avatar to fill its box, so shrinking the box just shrinks the
+   whole panel. Keep the box full-size and scale the rendered avatar to half instead. */
+.right :global(.CustomWearablePreview .WearablePreview) {
+  transform: scale(0.5);
 }
 
 .changeAccount {

--- a/src/components/Pages/RequestPage/Container/Container.module.css
+++ b/src/components/Pages/RequestPage/Container/Container.module.css
@@ -32,6 +32,7 @@
    bare styled iframe with an emotion-generated class, so there is no .WearablePreview hook. */
 .right :global(.CustomWearablePreview iframe) {
   transform: scale(0.5);
+  transform-origin: center;
 }
 
 .changeAccount {

--- a/src/components/Pages/RequestPage/Container/Container.module.css
+++ b/src/components/Pages/RequestPage/Container/Container.module.css
@@ -22,10 +22,16 @@
 
 .right {
   height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
+/* Half the previous size (was 100% x 100% of the right column): the fixed-camera
+   preview scales with its container, so the avatar renders half as big. */
 .right :global(.CustomWearablePreview) {
-  right: 8%;
+  width: 50%;
+  height: 50%;
 }
 
 .changeAccount {

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -313,7 +313,7 @@ export const RequestPage = () => {
 
     // Client-login flow: no request to recover. Post the identity generated during login
     // to the auth server and let the client retrieve it through the `open?signin=<id>`
-    // deep link, which ContinueInApp fires immediately for this flow.
+    // deep link, which ContinueInApp opens automatically once its countdown ends.
     const completeClientLoginFlow = async () => {
       identifyUser(account)
 
@@ -922,7 +922,7 @@ export const RequestPage = () => {
           onContinue={onContinueInApp}
           requestId={requestId}
           deepLinkUrl={getSigninDeeplink(targetConfig.deepLink, identityId ?? '', isBridgeOnly)}
-          immediate={isClientLoginFlow}
+          isClientLogin={isClientLoginFlow}
         />
       )
     case View.VERIFY_SIGN_IN_DENIED:

--- a/src/components/Pages/RequestPage/Views/ContinueInApp.spec.tsx
+++ b/src/components/Pages/RequestPage/Views/ContinueInApp.spec.tsx
@@ -15,7 +15,12 @@ jest.mock('../../../../hooks/targetConfig', () => ({
 }))
 
 jest.mock('../Container', () => ({
-  Container: (props: { children: ReactNode }) => <div>{props.children}</div>
+  Container: (props: { children: ReactNode; canChangeAccount?: boolean }) => (
+    <div>
+      {props.canChangeAccount ? <div data-testid="change-account-link" /> : null}
+      {props.children}
+    </div>
+  )
 }))
 
 jest.mock('@dcl/hooks', () => ({
@@ -39,8 +44,8 @@ describe('ContinueInApp', () => {
   let originalLocation: Location
   let mockOnContinue: jest.Mock
 
-  const renderContinueInApp = (options: { immediate?: boolean; autoStart?: boolean } = {}) => {
-    const { immediate = false, autoStart = true } = options
+  const renderContinueInApp = (options: { isClientLogin?: boolean; autoStart?: boolean } = {}) => {
+    const { isClientLogin = false, autoStart = true } = options
     return render(
       <MemoryRouter initialEntries={['/auth/requests/aRequestId?targetConfigId=default&flow=deeplink']}>
         <ContinueInApp
@@ -48,7 +53,7 @@ describe('ContinueInApp', () => {
           requestId="aRequestId"
           deepLinkUrl={DEEP_LINK_URL}
           autoStart={autoStart}
-          immediate={immediate}
+          isClientLogin={isClientLogin}
         />
       </MemoryRouter>
     )
@@ -71,21 +76,52 @@ describe('ContinueInApp', () => {
     jest.resetAllMocks()
   })
 
-  describe('when using the countdown flow', () => {
-    describe('and the view has just mounted', () => {
-      beforeEach(() => {
-        renderContinueInApp()
+  describe('when the view has just mounted', () => {
+    beforeEach(() => {
+      renderContinueInApp()
+    })
+
+    it('should not attempt the deep link before the countdown finishes', () => {
+      expect(mockedLaunchDeepLink).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when opening the client from the return button', () => {
+    describe('and the deep link launches successfully', () => {
+      beforeEach(async () => {
+        mockedLaunchDeepLink.mockResolvedValueOnce(true)
+        renderContinueInApp({ autoStart: false })
+        await userEvent.click(screen.getByTestId('continue-in-app-return-button'))
+        await waitFor(() => {
+          expect(mockOnContinue).toHaveBeenCalled()
+        })
       })
 
-      it('should not attempt the deep link before the countdown finishes', () => {
-        expect(mockedLaunchDeepLink).not.toHaveBeenCalled()
+      it('should attempt to launch the deep link', () => {
+        expect(mockedLaunchDeepLink).toHaveBeenCalledWith(DEEP_LINK_URL)
+      })
+
+      it('should notify the continue callback', () => {
+        expect(mockOnContinue).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('when it is a regular deep-link flow', () => {
+    describe('and the view has just mounted', () => {
+      beforeEach(() => {
+        renderContinueInApp({ isClientLogin: false })
+      })
+
+      it('should not offer the change-account link', () => {
+        expect(screen.queryByTestId('change-account-link')).not.toBeInTheDocument()
       })
     })
 
     describe('and the deep link fails to launch', () => {
       beforeEach(async () => {
         mockedLaunchDeepLink.mockResolvedValueOnce(false)
-        renderContinueInApp({ autoStart: false })
+        renderContinueInApp({ isClientLogin: false, autoStart: false })
         await userEvent.click(screen.getByTestId('continue-in-app-return-button'))
         await waitFor(() => {
           expect(screen.getByTestId('continue-in-app-go-back-button')).toBeInTheDocument()
@@ -101,30 +137,22 @@ describe('ContinueInApp', () => {
     })
   })
 
-  describe('when using the immediate flow', () => {
-    describe('and the deep link launches successfully', () => {
+  describe('when it is the client-login flow', () => {
+    describe('and the view has just mounted', () => {
       beforeEach(() => {
-        mockedLaunchDeepLink.mockResolvedValueOnce(true)
-        renderContinueInApp({ immediate: true })
+        renderContinueInApp({ isClientLogin: true })
       })
 
-      it('should attempt the deep link immediately without a countdown', async () => {
-        await waitFor(() => {
-          expect(mockedLaunchDeepLink).toHaveBeenCalledWith(DEEP_LINK_URL)
-        })
-      })
-
-      it('should notify the continue callback', async () => {
-        await waitFor(() => {
-          expect(mockOnContinue).toHaveBeenCalled()
-        })
+      it('should offer the change-account link so the user can switch wallets', () => {
+        expect(screen.getByTestId('change-account-link')).toBeInTheDocument()
       })
     })
 
     describe('and the deep link fails to launch', () => {
       beforeEach(async () => {
         mockedLaunchDeepLink.mockResolvedValueOnce(false)
-        renderContinueInApp({ immediate: true })
+        renderContinueInApp({ isClientLogin: true, autoStart: false })
+        await userEvent.click(screen.getByTestId('continue-in-app-return-button'))
         await waitFor(() => {
           expect(screen.getByTestId('continue-in-app-try-again-button')).toBeInTheDocument()
         })
@@ -134,21 +162,17 @@ describe('ContinueInApp', () => {
         expect(screen.queryByTestId('continue-in-app-go-back-button')).not.toBeInTheDocument()
       })
 
+      it('should still offer the change-account link so the user can switch wallets', () => {
+        expect(screen.getByTestId('change-account-link')).toBeInTheDocument()
+      })
+
       describe('and trying again', () => {
         beforeEach(async () => {
-          mockedLaunchDeepLink.mockResolvedValueOnce(true)
           await userEvent.click(screen.getByTestId('continue-in-app-try-again-button'))
-          await waitFor(() => {
-            expect(mockedLaunchDeepLink).toHaveBeenCalledTimes(2)
-          })
         })
 
-        it('should re-attempt the deep link', () => {
-          expect(mockedLaunchDeepLink).toHaveBeenCalledTimes(2)
-        })
-
-        it('should not navigate anywhere', () => {
-          expect(window.location.href).toBe('')
+        it('should return to the redirecting view', () => {
+          expect(screen.getByTestId('continue-in-app-return-button')).toBeInTheDocument()
         })
       })
     })

--- a/src/components/Pages/RequestPage/Views/ContinueInApp.spec.tsx
+++ b/src/components/Pages/RequestPage/Views/ContinueInApp.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { launchDeepLink } from '../utils'
 import { ContinueInApp } from './ContinueInApp'
@@ -39,6 +39,8 @@ jest.mock('decentraland-ui2', () => ({
 const mockedLaunchDeepLink = launchDeepLink as jest.MockedFunction<typeof launchDeepLink>
 
 const DEEP_LINK_URL = 'decentraland://open?signin=anIdentityId'
+// Matches COUNTDOWN_SECONDS (5) in the component: the interval decrements once per second.
+const COUNTDOWN_MS = 5000
 
 describe('ContinueInApp', () => {
   let originalLocation: Location
@@ -83,6 +85,69 @@ describe('ContinueInApp', () => {
 
     it('should not attempt the deep link before the countdown finishes', () => {
       expect(mockedLaunchDeepLink).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when the countdown runs to completion', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+      mockedLaunchDeepLink.mockResolvedValue(true)
+      renderContinueInApp({ isClientLogin: true })
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('should launch the deep link automatically when it reaches zero', async () => {
+      await act(async () => {
+        jest.advanceTimersByTime(COUNTDOWN_MS)
+      })
+      expect(mockedLaunchDeepLink).toHaveBeenCalledWith(DEEP_LINK_URL)
+    })
+
+    it('should launch the deep link only once', async () => {
+      await act(async () => {
+        jest.advanceTimersByTime(COUNTDOWN_MS * 2)
+      })
+      expect(mockedLaunchDeepLink).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when the return button is pressed while the countdown is finishing', () => {
+    let resolveLaunch: (value: boolean) => void
+
+    beforeEach(() => {
+      jest.useFakeTimers()
+      // Keep the launch in flight so the countdown's zero-tick fires before it resolves.
+      mockedLaunchDeepLink.mockReturnValue(
+        new Promise<boolean>(resolve => {
+          resolveLaunch = resolve
+        })
+      )
+      renderContinueInApp({ isClientLogin: true })
+      fireEvent.click(screen.getByTestId('continue-in-app-return-button'))
+      act(() => {
+        jest.advanceTimersByTime(COUNTDOWN_MS)
+      })
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('should open the client only once', async () => {
+      await act(async () => {
+        resolveLaunch(true)
+      })
+      expect(mockedLaunchDeepLink).toHaveBeenCalledTimes(1)
+    })
+
+    it('should notify the continue callback only once', async () => {
+      await act(async () => {
+        resolveLaunch(true)
+      })
+      expect(mockOnContinue).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -173,6 +238,14 @@ describe('ContinueInApp', () => {
 
         it('should return to the redirecting view', () => {
           expect(screen.getByTestId('continue-in-app-return-button')).toBeInTheDocument()
+        })
+
+        it('should re-attempt the deep link when the client is reopened', async () => {
+          mockedLaunchDeepLink.mockResolvedValueOnce(true)
+          await userEvent.click(screen.getByTestId('continue-in-app-return-button'))
+          await waitFor(() => {
+            expect(mockedLaunchDeepLink).toHaveBeenCalledTimes(2)
+          })
         })
       })
     })

--- a/src/components/Pages/RequestPage/Views/ContinueInApp.tsx
+++ b/src/components/Pages/RequestPage/Views/ContinueInApp.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useTranslation } from '@dcl/hooks'
 import { muiIcons } from 'decentraland-ui2'
@@ -16,27 +16,31 @@ type Props = {
   requestId: string
   deepLinkUrl: string
   autoStart?: boolean
-  // When true (client-login flow), open the client immediately with no countdown and, since
-  // there is no traditional request flow to fall back to, offer a plain retry of the deep
-  // link on failure instead of the go-back-to-login fallback.
-  immediate?: boolean
+  // When true (client-login flow) the deep link opens the client after a successful login
+  // rather than approving a request. There is no traditional request flow to fall back to,
+  // so failure offers a plain retry instead of go-back-to-login, and — since this is the
+  // first screen the user sees (no VerifySignIn precedes it) — it offers the change-account
+  // link like the classic request views do.
+  isClientLogin?: boolean
 }
 
 const COUNTDOWN_SECONDS = 5
 
-export const ContinueInApp = ({ onContinue, requestId, deepLinkUrl, autoStart = true, immediate = false }: Props) => {
+export const ContinueInApp = ({ onContinue, requestId, deepLinkUrl, autoStart = true, isClientLogin = false }: Props) => {
   const { t } = useTranslation()
   const [targetConfig] = useTargetConfig()
   const [searchParams] = useSearchParams()
   const [countdown, setCountdown] = useState(COUNTDOWN_SECONDS)
   const [deepLinkFailed, setDeepLinkFailed] = useState(false)
-  // Guards the immediate auto-launch so it fires once even though React StrictMode
-  // double-invokes effects in dev; handleRetry resets it so a retry can launch again.
-  const hasAutoLaunchedRef = useRef(false)
+  // The client-login view stays mounted after a successful launch (there is nothing to
+  // navigate to), so track the launch to stop the countdown from opening the client twice
+  // — e.g. if the user hits "Return to <Explorer>" before the countdown reaches zero.
+  const [hasLaunched, setHasLaunched] = useState(false)
 
   const attemptDeepLink = useCallback(async () => {
     const wasLaunched = await launchDeepLink(deepLinkUrl)
     if (wasLaunched) {
+      setHasLaunched(true)
       onContinue()
     } else {
       setDeepLinkFailed(true)
@@ -52,31 +56,21 @@ export const ContinueInApp = ({ onContinue, requestId, deepLinkUrl, autoStart = 
     window.location.href = loginUrl
   }, [requestId, searchParams])
 
-  // Clearing the failed flag re-runs the launch effect; resetting the guard lets the
-  // immediate flow re-attempt the deep link.
+  // Restart the countdown so it re-attempts the deep link after the same delay.
   const handleRetry = useCallback(() => {
-    hasAutoLaunchedRef.current = false
+    setCountdown(COUNTDOWN_SECONDS)
     setDeepLinkFailed(false)
   }, [])
 
   useEffect(() => {
     if (!autoStart) return
-    if (deepLinkFailed) return
+    if (deepLinkFailed || hasLaunched) return
 
-    // Immediate flow (client-login): open the client right away, without the countdown.
-    if (immediate) {
-      if (hasAutoLaunchedRef.current) return
-      hasAutoLaunchedRef.current = true
-      attemptDeepLink()
-      return
-    }
-
-    // Start countdown
+    // Count down, then open the client automatically when it reaches zero.
     const interval = setInterval(() => {
       setCountdown(prev => {
         if (prev <= 1) {
           clearInterval(interval)
-          // Auto-attempt deep link when countdown reaches 0
           attemptDeepLink()
           return 0
         }
@@ -85,18 +79,18 @@ export const ContinueInApp = ({ onContinue, requestId, deepLinkUrl, autoStart = 
     }, 1000)
 
     return () => clearInterval(interval)
-  }, [attemptDeepLink, autoStart, deepLinkFailed, immediate])
+  }, [attemptDeepLink, autoStart, deepLinkFailed, hasLaunched])
 
   if (deepLinkFailed) {
     return (
-      <Container canChangeAccount={false} requestId={requestId}>
+      <Container canChangeAccount={isClientLogin} requestId={requestId}>
         <div className={styles.errorLogo}></div>
         <div className={styles.title}>{t('request_views.continue_in_app.could_not_open', { explorerText: targetConfig.explorerText })}</div>
         <div className={styles.description}>
           {t('request_views.continue_in_app.app_not_launched', { explorerText: targetConfig.explorerText })}
         </div>
 
-        {immediate ? (
+        {isClientLogin ? (
           <ActionButton variant="contained" onClick={handleRetry} startIcon={<LoginIcon />} data-testid="continue-in-app-try-again-button">
             {t('common.try_again')}
           </ActionButton>
@@ -115,11 +109,11 @@ export const ContinueInApp = ({ onContinue, requestId, deepLinkUrl, autoStart = 
   }
 
   return (
-    <Container canChangeAccount={false} requestId={requestId}>
+    <Container canChangeAccount={isClientLogin} requestId={requestId}>
       <div className={styles.logo}></div>
       <div className={styles.title}>{t('request_views.continue_in_app.sign_in_successful')}</div>
       <div className={styles.description}>
-        {immediate
+        {hasLaunched
           ? t('request_views.continue_in_app.redirecting', { explorerText: targetConfig.explorerText })
           : t('request_views.continue_in_app.redirect_countdown', { explorerText: targetConfig.explorerText, countdown })}
       </div>

--- a/src/components/Pages/RequestPage/Views/ContinueInApp.tsx
+++ b/src/components/Pages/RequestPage/Views/ContinueInApp.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useTranslation } from '@dcl/hooks'
 import { muiIcons } from 'decentraland-ui2'
@@ -33,17 +33,28 @@ export const ContinueInApp = ({ onContinue, requestId, deepLinkUrl, autoStart = 
   const [countdown, setCountdown] = useState(COUNTDOWN_SECONDS)
   const [deepLinkFailed, setDeepLinkFailed] = useState(false)
   // The client-login view stays mounted after a successful launch (there is nothing to
-  // navigate to), so track the launch to stop the countdown from opening the client twice
-  // — e.g. if the user hits "Return to <Explorer>" before the countdown reaches zero.
+  // navigate to), so track the launch to swap the copy to "redirecting" and keep the
+  // countdown effect from starting a new interval.
   const [hasLaunched, setHasLaunched] = useState(false)
+  // Set synchronously before the async launch to drop any overlapping call: the manual
+  // "Return to <Explorer>" button and the countdown's zero-tick can both fire while a
+  // launch is still in flight (hasLaunched only flips once it resolves), which would open
+  // the client and call onContinue twice.
+  const isLaunchingRef = useRef(false)
 
   const attemptDeepLink = useCallback(async () => {
-    const wasLaunched = await launchDeepLink(deepLinkUrl)
-    if (wasLaunched) {
-      setHasLaunched(true)
-      onContinue()
-    } else {
-      setDeepLinkFailed(true)
+    if (isLaunchingRef.current) return
+    isLaunchingRef.current = true
+    try {
+      const wasLaunched = await launchDeepLink(deepLinkUrl)
+      if (wasLaunched) {
+        setHasLaunched(true)
+        onContinue()
+      } else {
+        setDeepLinkFailed(true)
+      }
+    } finally {
+      isLaunchingRef.current = false
     }
   }, [deepLinkUrl, onContinue])
 

--- a/src/components/Pages/RequestPage/Views/ContinueInApp.tsx
+++ b/src/components/Pages/RequestPage/Views/ContinueInApp.tsx
@@ -73,24 +73,24 @@ export const ContinueInApp = ({ onContinue, requestId, deepLinkUrl, autoStart = 
     setDeepLinkFailed(false)
   }, [])
 
+  // Tick the countdown down once per second. The updater stays pure — the launch is
+  // triggered by the effect below when the countdown reaches zero — so a StrictMode
+  // double-invoke of the updater can't fire the deep link twice.
   useEffect(() => {
-    if (!autoStart) return
-    if (deepLinkFailed || hasLaunched) return
+    if (!autoStart || deepLinkFailed || hasLaunched) return
 
-    // Count down, then open the client automatically when it reaches zero.
     const interval = setInterval(() => {
-      setCountdown(prev => {
-        if (prev <= 1) {
-          clearInterval(interval)
-          attemptDeepLink()
-          return 0
-        }
-        return prev - 1
-      })
+      setCountdown(prev => (prev <= 0 ? 0 : prev - 1))
     }, 1000)
 
     return () => clearInterval(interval)
-  }, [attemptDeepLink, autoStart, deepLinkFailed, hasLaunched])
+  }, [autoStart, deepLinkFailed, hasLaunched])
+
+  // Open the client automatically once the countdown reaches zero.
+  useEffect(() => {
+    if (!autoStart || deepLinkFailed || hasLaunched) return
+    if (countdown === 0) attemptDeepLink()
+  }, [attemptDeepLink, autoStart, countdown, deepLinkFailed, hasLaunched])
 
   if (deepLinkFailed) {
     return (


### PR DESCRIPTION
## What

Two related tweaks to the request views, focused on the `/auth/requests/client-login` page.

### 1. Change wallet from the client-login success view

The client-login page is only reached with an active identity, so it represents a **successful login**. It now behaves like the classic deep-link request flow instead of opening the client instantly:

- **Auto-open the Explorer via the countdown timer** (previously it opened immediately with no countdown).
- **Keeps the "Return to {Explorer}" button** so the user can open the client before the countdown ends.
- **Shows the "Use another profile? → Return to log in" change-account link**, so the user can log in with a different wallet — just like the classic request views (`VerifySignIn`, `WalletInteraction`, …).

Implementation notes:
- Renamed the `ContinueInApp` `immediate` prop to `isClientLogin`. It no longer means "skip the countdown"; it gates the client-login-only behavior (the change-account link and the retry-on-failure fallback vs. go-back-to-login).
- Added a `hasLaunched` guard so the still-mounted view isn't re-opened by the countdown after the user clicks "Return to {Explorer}".

### 2. Halve the avatar preview size across request views

The wearable preview filled the entire right column (100% × 100%) of the shared request `Container`, so it rendered oversized on **every** request view — not just client-login. It's now constrained to 50% × 50% and centered, so the fixed-camera avatar renders half as big everywhere.

## Testing

- `tsc --noEmit`: clean
- ESLint on changed files: clean
- Jest `src/components/Pages/RequestPage`: 90 passed (incl. `ContinueInApp.spec.tsx` restructured around `isClientLogin`, covering countdown auto-open, the return button, the change-account link per flow, and the retry fallback)

⚠️ Not yet verified by driving the live wallet flow end-to-end — a quick visual pass on the client-login page (countdown, button, bottom link, smaller avatar) is recommended before merge.