### PR TITLE
feat: add authRequestId param and rename bridge-only to bridgeOnly

### DIFF
--- a/src/components/Pages/RequestPage/Container/Container.tsx
+++ b/src/components/Pages/RequestPage/Container/Container.tsx
@@ -6,7 +6,7 @@ import { useMobileMediaQuery } from 'decentraland-ui2'
 import { useNavigateWithSearchParams } from '../../../../hooks/navigation'
 import { useTargetConfig } from '../../../../hooks/targetConfig'
 import { useCurrentConnectionData } from '../../../../shared/connection'
-import { isBridgeOnlyEnabled } from '../../../../shared/locations'
+import { getAuthRequestId, isBridgeOnlyEnabled } from '../../../../shared/locations'
 import { AnimatedBackground } from '../../../AnimatedBackground'
 import { CustomWearablePreview } from '../../../CustomWearablePreview'
 import styles from './Container.module.css'
@@ -22,6 +22,7 @@ export const Container = (props: { children: ReactNode; requestId?: string; canC
   const { account } = useCurrentConnectionData()
   const isDeepLinkFlow = searchParams.get('flow') === 'deeplink'
   const isBridgeOnly = isBridgeOnlyEnabled(searchParams)
+  const authRequestId = getAuthRequestId(searchParams)
 
   const onChangeAccount = useCallback(
     async (evt: React.MouseEvent<HTMLAnchorElement>) => {
@@ -29,11 +30,12 @@ export const Container = (props: { children: ReactNode; requestId?: string; canC
       await connection.disconnect()
       const flowParam = isDeepLinkFlow ? '&flow=deeplink' : ''
       const bridgeOnlyParam = isBridgeOnly ? '&bridge-only=true' : ''
+      const authRequestIdParam = authRequestId ? `&authRequestId=${encodeURIComponent(authRequestId)}` : ''
       // Don't preserve loginMethod — the user explicitly wants to choose a different method
-      const redirectToUrl = `/auth/requests/${requestId ?? ''}?targetConfigId=${targetConfigId}${flowParam}${bridgeOnlyParam}`
+      const redirectToUrl = `/auth/requests/${requestId ?? ''}?targetConfigId=${targetConfigId}${flowParam}${bridgeOnlyParam}${authRequestIdParam}`
       navigate(`/login?redirectTo=${encodeURIComponent(redirectToUrl)}`)
     },
-    [requestId, targetConfigId, isDeepLinkFlow, isBridgeOnly, navigate]
+    [requestId, targetConfigId, isDeepLinkFlow, isBridgeOnly, authRequestId, navigate]
   )
 
   return (

--- a/src/components/Pages/RequestPage/Container/Container.tsx
+++ b/src/components/Pages/RequestPage/Container/Container.tsx
@@ -6,7 +6,7 @@ import { useMobileMediaQuery } from 'decentraland-ui2'
 import { useNavigateWithSearchParams } from '../../../../hooks/navigation'
 import { useTargetConfig } from '../../../../hooks/targetConfig'
 import { useCurrentConnectionData } from '../../../../shared/connection'
-import { getAuthRequestId, isBridgeOnlyEnabled } from '../../../../shared/locations'
+import { buildRequestPageUrl, getAuthRequestId, isBridgeOnlyEnabled } from '../../../../shared/locations'
 import { AnimatedBackground } from '../../../AnimatedBackground'
 import { CustomWearablePreview } from '../../../CustomWearablePreview'
 import styles from './Container.module.css'
@@ -28,11 +28,8 @@ export const Container = (props: { children: ReactNode; requestId?: string; canC
     async (evt: React.MouseEvent<HTMLAnchorElement>) => {
       evt.preventDefault()
       await connection.disconnect()
-      const flowParam = isDeepLinkFlow ? '&flow=deeplink' : ''
-      const bridgeOnlyParam = isBridgeOnly ? '&bridgeOnly=true' : ''
-      const authRequestIdParam = authRequestId ? `&authRequestId=${encodeURIComponent(authRequestId)}` : ''
       // Don't preserve loginMethod — the user explicitly wants to choose a different method
-      const redirectToUrl = `/auth/requests/${requestId ?? ''}?targetConfigId=${targetConfigId}${flowParam}${bridgeOnlyParam}${authRequestIdParam}`
+      const redirectToUrl = buildRequestPageUrl(requestId ?? '', targetConfigId, { isDeepLinkFlow, isBridgeOnly, authRequestId })
       navigate(`/login?redirectTo=${encodeURIComponent(redirectToUrl)}`)
     },
     [requestId, targetConfigId, isDeepLinkFlow, isBridgeOnly, authRequestId, navigate]

--- a/src/components/Pages/RequestPage/Container/Container.tsx
+++ b/src/components/Pages/RequestPage/Container/Container.tsx
@@ -29,7 +29,7 @@ export const Container = (props: { children: ReactNode; requestId?: string; canC
       evt.preventDefault()
       await connection.disconnect()
       const flowParam = isDeepLinkFlow ? '&flow=deeplink' : ''
-      const bridgeOnlyParam = isBridgeOnly ? '&bridge-only=true' : ''
+      const bridgeOnlyParam = isBridgeOnly ? '&bridgeOnly=true' : ''
       const authRequestIdParam = authRequestId ? `&authRequestId=${encodeURIComponent(authRequestId)}` : ''
       // Don't preserve loginMethod — the user explicitly wants to choose a different method
       const redirectToUrl = `/auth/requests/${requestId ?? ''}?targetConfigId=${targetConfigId}${flowParam}${bridgeOnlyParam}${authRequestIdParam}`

--- a/src/components/Pages/RequestPage/RequestPage.spec.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.spec.tsx
@@ -11,7 +11,7 @@ import {
   IpValidationError,
   RequestFulfilledError
 } from '../../../shared/auth'
-import { isBridgeOnlyEnabled } from '../../../shared/locations'
+import { getAuthRequestId, isBridgeOnlyEnabled } from '../../../shared/locations'
 import { isProfileComplete } from '../../../shared/profile'
 import { FeatureFlagsContext } from '../../FeatureFlagsProvider'
 import { RequestPage } from './RequestPage'
@@ -80,6 +80,7 @@ jest.mock('../../../shared/auth', () => {
 jest.mock('../../../shared/locations', () => ({
   extractReferrerFromSearchParameters: jest.fn().mockReturnValue(null),
   isBridgeOnlyEnabled: jest.fn().mockReturnValue(false),
+  getAuthRequestId: jest.fn().mockReturnValue(null),
   CLIENT_LOGIN_REQUEST_ID: 'client-login',
   buildRequestPageUrl: (requestId: string, targetConfigId: string) => `/auth/requests/${requestId}?targetConfigId=${targetConfigId}`
 }))
@@ -507,12 +508,12 @@ describe('RequestPage', () => {
           expect(mockRecover).not.toHaveBeenCalled()
         })
 
-        it('should build the signin deep link without the bridge-only flag', async () => {
+        it('should build the signin deep link without the bridge-only flag or an authRequestId', async () => {
           renderRequestPage(CLIENT_LOGIN_REQUEST_PATH)
           await waitFor(() => {
             expect(screen.getByTestId('continue-in-app')).toBeInTheDocument()
           })
-          expect(jest.mocked(getSigninDeeplink)).toHaveBeenCalledWith(undefined, 'anIdentityId', false)
+          expect(jest.mocked(getSigninDeeplink)).toHaveBeenCalledWith(undefined, 'anIdentityId', false, null)
         })
       })
 
@@ -531,7 +532,26 @@ describe('RequestPage', () => {
           await waitFor(() => {
             expect(screen.getByTestId('continue-in-app')).toBeInTheDocument()
           })
-          expect(jest.mocked(getSigninDeeplink)).toHaveBeenCalledWith(undefined, 'anIdentityId', true)
+          expect(jest.mocked(getSigninDeeplink)).toHaveBeenCalledWith(undefined, 'anIdentityId', true, null)
+        })
+      })
+
+      describe('and an authRequestId is provided', () => {
+        beforeEach(() => {
+          jest.mocked(getAuthRequestId).mockReturnValue('auth-req-abc')
+          mockPostIdentity.mockResolvedValueOnce({ identityId: 'anIdentityId' })
+        })
+
+        afterEach(() => {
+          jest.mocked(getAuthRequestId).mockReturnValue(null)
+        })
+
+        it('should build the signin deep link forwarding the authRequestId verbatim', async () => {
+          renderRequestPage(CLIENT_LOGIN_REQUEST_PATH)
+          await waitFor(() => {
+            expect(screen.getByTestId('continue-in-app')).toBeInTheDocument()
+          })
+          expect(jest.mocked(getSigninDeeplink)).toHaveBeenCalledWith(undefined, 'anIdentityId', false, 'auth-req-abc')
         })
       })
 

--- a/src/components/Pages/RequestPage/RequestPage.spec.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.spec.tsx
@@ -508,7 +508,7 @@ describe('RequestPage', () => {
           expect(mockRecover).not.toHaveBeenCalled()
         })
 
-        it('should build the signin deep link without the bridge-only flag or an authRequestId', async () => {
+        it('should build the signin deep link without the bridgeOnly flag or an authRequestId', async () => {
           renderRequestPage(CLIENT_LOGIN_REQUEST_PATH)
           await waitFor(() => {
             expect(screen.getByTestId('continue-in-app')).toBeInTheDocument()
@@ -517,7 +517,7 @@ describe('RequestPage', () => {
         })
       })
 
-      describe('and the bridge-only flag is enabled', () => {
+      describe('and the bridgeOnly flag is enabled', () => {
         beforeEach(() => {
           jest.mocked(isBridgeOnlyEnabled).mockReturnValue(true)
           mockPostIdentity.mockResolvedValueOnce({ identityId: 'anIdentityId' })
@@ -527,7 +527,7 @@ describe('RequestPage', () => {
           jest.mocked(isBridgeOnlyEnabled).mockReturnValue(false)
         })
 
-        it('should build the signin deep link with the bridge-only flag', async () => {
+        it('should build the signin deep link with the bridgeOnly flag', async () => {
           renderRequestPage(CLIENT_LOGIN_REQUEST_PATH)
           await waitFor(() => {
             expect(screen.getByTestId('continue-in-app')).toBeInTheDocument()

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -32,6 +32,7 @@ import {
   CLIENT_LOGIN_REQUEST_ID,
   buildRequestPageUrl,
   extractReferrerFromSearchParameters,
+  getAuthRequestId,
   isBridgeOnlyEnabled
 } from '../../../shared/locations'
 import { sendTipNotification } from '../../../shared/notifications'
@@ -211,16 +212,19 @@ export const RequestPage = () => {
   // The bridge-only flag rides inside redirectTo so it survives logins/callbacks and can be
   // appended to the client deep link once the flow completes.
   const isBridgeOnly = isBridgeOnlyEnabled(searchParams)
+  // Like bridge-only: rides inside redirectTo across logins/callbacks and is forwarded
+  // verbatim onto the client deep link.
+  const authRequestId = getAuthRequestId(searchParams)
   // Goes to the login page where the user will have to connect a wallet.
   // Preserve loginMethod from current URL if present for auto-login functionality
   const loginMethodParam = searchParams.get('loginMethod')
 
   const toLoginPage = useCallback(() => {
-    const redirectToUrl = buildRequestPageUrl(requestId, targetConfigId, { isDeepLinkFlow, isBridgeOnly })
+    const redirectToUrl = buildRequestPageUrl(requestId, targetConfigId, { isDeepLinkFlow, isBridgeOnly, authRequestId })
     const loginMethodQuery = loginMethodParam ? `&loginMethod=${encodeURIComponent(loginMethodParam)}` : ''
     const finalUrl = `/login?redirectTo=${encodeURIComponent(redirectToUrl)}${loginMethodQuery}`
     navigate(finalUrl)
-  }, [requestId, targetConfigId, isDeepLinkFlow, isBridgeOnly, loginMethodParam, navigate])
+  }, [requestId, targetConfigId, isDeepLinkFlow, isBridgeOnly, authRequestId, loginMethodParam, navigate])
 
   // Effect 1: Ensure profile consistency before allowing request loading.
   // Navigates to setup if the profile is incomplete or missing.
@@ -241,7 +245,7 @@ export const RequestPage = () => {
     let cancelled = false
 
     const checkProfile = async () => {
-      const redirectTo = buildRequestPageUrl(requestId, targetConfigId, { isDeepLinkFlow, isBridgeOnly })
+      const redirectTo = buildRequestPageUrl(requestId, targetConfigId, { isDeepLinkFlow, isBridgeOnly, authRequestId })
       const referrer = extractReferrerFromSearchParameters(searchParams)
       const profile = await ensureProfile(account, identityRef.current, { redirectTo, referrer })
 
@@ -266,6 +270,7 @@ export const RequestPage = () => {
     targetConfigId,
     isDeepLinkFlow,
     isBridgeOnly,
+    authRequestId,
     searchParams,
     skipSetup
   ])
@@ -657,7 +662,7 @@ export const RequestPage = () => {
         // Route through getExplorerDeeplink so this bare redirect carries the same
         // query params (dclenv, bridge-only) as the other deep-link generation sites.
         if (targetConfig.deepLink) {
-          window.location.href = getExplorerDeeplink(targetConfig.deepLink, isBridgeOnly)
+          window.location.href = getExplorerDeeplink(targetConfig.deepLink, isBridgeOnly, authRequestId)
         }
       }
     } catch (e) {
@@ -695,7 +700,7 @@ export const RequestPage = () => {
         setIsLoading(false)
       }
     }
-  }, [setIsLoading, isUserUsingWeb2Wallet, isLoading, identity, isBridgeOnly])
+  }, [setIsLoading, isUserUsingWeb2Wallet, isLoading, identity, isBridgeOnly, authRequestId])
 
   const onDenyWalletInteraction = useCallback(async () => {
     setIsLoading(true)
@@ -899,7 +904,7 @@ export const RequestPage = () => {
       return (
         <RecoverError
           onTryAgain={() => {
-            window.location.href = getExplorerDeeplink(targetConfig.deepLink, isBridgeOnly)
+            window.location.href = getExplorerDeeplink(targetConfig.deepLink, isBridgeOnly, authRequestId)
           }}
         />
       )
@@ -912,7 +917,12 @@ export const RequestPage = () => {
       // From Explorer (skipSetup enabled): show full-page success with Continue button
       // From web (has redirectTo): show minimal success view
       return skipSetup ? (
-        <SignInCompletePage skipRedirect={skipDeepLinkRedirect} deepLink={targetConfig.deepLink} bridgeOnly={isBridgeOnly} />
+        <SignInCompletePage
+          skipRedirect={skipDeepLinkRedirect}
+          deepLink={targetConfig.deepLink}
+          bridgeOnly={isBridgeOnly}
+          authRequestId={authRequestId}
+        />
       ) : (
         <SignInComplete />
       )
@@ -921,7 +931,7 @@ export const RequestPage = () => {
         <ContinueInApp
           onContinue={onContinueInApp}
           requestId={requestId}
-          deepLinkUrl={getSigninDeeplink(targetConfig.deepLink, identityId ?? '', isBridgeOnly)}
+          deepLinkUrl={getSigninDeeplink(targetConfig.deepLink, identityId ?? '', isBridgeOnly, authRequestId)}
           isClientLogin={isClientLoginFlow}
         />
       )

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -209,10 +209,10 @@ export const RequestPage = () => {
   // whole recover/verify flow and hand the signed identity to the client via the deep
   // link, the same way the standalone mobile flow does.
   const isClientLoginFlow = requestId === CLIENT_LOGIN_REQUEST_ID
-  // The bridge-only flag rides inside redirectTo so it survives logins/callbacks and can be
+  // The bridgeOnly flag rides inside redirectTo so it survives logins/callbacks and can be
   // appended to the client deep link once the flow completes.
   const isBridgeOnly = isBridgeOnlyEnabled(searchParams)
-  // Like bridge-only: rides inside redirectTo across logins/callbacks and is forwarded
+  // Like bridgeOnly: rides inside redirectTo across logins/callbacks and is forwarded
   // verbatim onto the client deep link.
   const authRequestId = getAuthRequestId(searchParams)
   // Goes to the login page where the user will have to connect a wallet.
@@ -660,7 +660,7 @@ export const RequestPage = () => {
         // For mobile deep-link flow, auto-redirect. For Explorer (skipSetup),
         // the SignInCompletePage shows a Continue button that triggers the deeplink.
         // Route through getExplorerDeeplink so this bare redirect carries the same
-        // query params (dclenv, bridge-only) as the other deep-link generation sites.
+        // query params (dclenv, bridgeOnly) as the other deep-link generation sites.
         if (targetConfig.deepLink) {
           window.location.href = getExplorerDeeplink(targetConfig.deepLink, isBridgeOnly, authRequestId)
         }

--- a/src/components/Pages/RequestPage/Views/SignInCompletePage.tsx
+++ b/src/components/Pages/RequestPage/Views/SignInCompletePage.tsx
@@ -10,17 +10,18 @@ type Props = {
   deepLink?: string
   skipRedirect?: boolean
   bridgeOnly?: boolean
+  authRequestId?: string | null
 }
 
-const SignInCompletePage = ({ onContinue, deepLink, skipRedirect, bridgeOnly }: Props) => {
+const SignInCompletePage = ({ onContinue, deepLink, skipRedirect, bridgeOnly, authRequestId }: Props) => {
   const { t } = useTranslation()
 
   useEffect(() => {
     onContinue?.()
     if (!skipRedirect) {
-      window.location.href = getExplorerDeeplink(deepLink, bridgeOnly)
+      window.location.href = getExplorerDeeplink(deepLink, bridgeOnly, authRequestId)
     }
-  }, [onContinue, deepLink, skipRedirect, bridgeOnly])
+  }, [onContinue, deepLink, skipRedirect, bridgeOnly, authRequestId])
 
   return (
     <CenteredContainer>

--- a/src/components/Pages/RequestPage/utils.spec.ts
+++ b/src/components/Pages/RequestPage/utils.spec.ts
@@ -829,6 +829,18 @@ describe('when building the explorer deep link', () => {
         expect(getExplorerDeeplink(deepLink, true)).toBe('decentraland://?bridge-only=true')
       })
     })
+
+    describe('and an authRequestId is provided', () => {
+      it('should append it verbatim alongside the bridge-only flag', () => {
+        expect(getExplorerDeeplink(deepLink, true, 'abc-123')).toBe('decentraland://?bridge-only=true&authRequestId=abc-123')
+      })
+    })
+
+    describe('and the authRequestId contains url-significant characters', () => {
+      it('should url-encode the authRequestId value', () => {
+        expect(getExplorerDeeplink(deepLink, false, 'a/b c')).toBe('decentraland://?authRequestId=a%2Fb+c')
+      })
+    })
   })
 
   describe('and the environment is development', () => {
@@ -904,6 +916,14 @@ describe('when building the signin deep link', () => {
     describe('and bridge-only is enabled', () => {
       it('should append the canonical bridge-only flag after the signin param', () => {
         expect(getSigninDeeplink(deepLink, identityId, true)).toBe('decentraland://open?signin=anIdentityId&bridge-only=true')
+      })
+    })
+
+    describe('and an authRequestId is provided', () => {
+      it('should append it verbatim after the signin and bridge-only params', () => {
+        expect(getSigninDeeplink(deepLink, identityId, true, 'abc-123')).toBe(
+          'decentraland://open?signin=anIdentityId&bridge-only=true&authRequestId=abc-123'
+        )
       })
     })
   })

--- a/src/components/Pages/RequestPage/utils.spec.ts
+++ b/src/components/Pages/RequestPage/utils.spec.ts
@@ -818,21 +818,21 @@ describe('when building the explorer deep link', () => {
       deepLink = 'decentraland://'
     })
 
-    describe('and bridge-only is disabled', () => {
+    describe('and bridgeOnly is disabled', () => {
       it('should return the bare deep link without query params', () => {
         expect(getExplorerDeeplink(deepLink, false)).toBe('decentraland://')
       })
     })
 
-    describe('and bridge-only is enabled', () => {
-      it('should append the canonical bridge-only flag', () => {
-        expect(getExplorerDeeplink(deepLink, true)).toBe('decentraland://?bridge-only=true')
+    describe('and bridgeOnly is enabled', () => {
+      it('should append the canonical bridgeOnly flag', () => {
+        expect(getExplorerDeeplink(deepLink, true)).toBe('decentraland://?bridgeOnly=true')
       })
     })
 
     describe('and an authRequestId is provided', () => {
-      it('should append it verbatim alongside the bridge-only flag', () => {
-        expect(getExplorerDeeplink(deepLink, true, 'abc-123')).toBe('decentraland://?bridge-only=true&authRequestId=abc-123')
+      it('should append it verbatim alongside the bridgeOnly flag', () => {
+        expect(getExplorerDeeplink(deepLink, true, 'abc-123')).toBe('decentraland://?bridgeOnly=true&authRequestId=abc-123')
       })
     })
 
@@ -849,15 +849,15 @@ describe('when building the explorer deep link', () => {
       deepLink = 'decentraland://'
     })
 
-    describe('and bridge-only is disabled', () => {
+    describe('and bridgeOnly is disabled', () => {
       it('should append only the dclenv zone param', () => {
         expect(getExplorerDeeplink(deepLink, false)).toBe('decentraland://?dclenv=zone')
       })
     })
 
-    describe('and bridge-only is enabled', () => {
-      it('should append both the dclenv zone param and the bridge-only flag', () => {
-        expect(getExplorerDeeplink(deepLink, true)).toBe('decentraland://?dclenv=zone&bridge-only=true')
+    describe('and bridgeOnly is enabled', () => {
+      it('should append both the dclenv zone param and the bridgeOnly flag', () => {
+        expect(getExplorerDeeplink(deepLink, true)).toBe('decentraland://?dclenv=zone&bridgeOnly=true')
       })
     })
   })
@@ -868,9 +868,9 @@ describe('when building the explorer deep link', () => {
       deepLink = 'dcl-creator-hub://'
     })
 
-    describe('and bridge-only is enabled', () => {
-      it('should append the raw env as dclenv alongside the bridge-only flag', () => {
-        expect(getExplorerDeeplink(deepLink, true)).toBe('dcl-creator-hub://?dclenv=staging&bridge-only=true')
+    describe('and bridgeOnly is enabled', () => {
+      it('should append the raw env as dclenv alongside the bridgeOnly flag', () => {
+        expect(getExplorerDeeplink(deepLink, true)).toBe('dcl-creator-hub://?dclenv=staging&bridgeOnly=true')
       })
     })
   })
@@ -881,9 +881,9 @@ describe('when building the explorer deep link', () => {
       deepLink = undefined
     })
 
-    describe('and bridge-only is enabled', () => {
-      it('should fall back to the decentraland scheme with the bridge-only flag', () => {
-        expect(getExplorerDeeplink(deepLink, true)).toBe('decentraland://?bridge-only=true')
+    describe('and bridgeOnly is enabled', () => {
+      it('should fall back to the decentraland scheme with the bridgeOnly flag', () => {
+        expect(getExplorerDeeplink(deepLink, true)).toBe('decentraland://?bridgeOnly=true')
       })
     })
   })
@@ -907,22 +907,22 @@ describe('when building the signin deep link', () => {
       deepLink = 'decentraland://'
     })
 
-    describe('and bridge-only is disabled', () => {
+    describe('and bridgeOnly is disabled', () => {
       it('should return the signin deep link without extra query params', () => {
         expect(getSigninDeeplink(deepLink, identityId, false)).toBe('decentraland://open?signin=anIdentityId')
       })
     })
 
-    describe('and bridge-only is enabled', () => {
-      it('should append the canonical bridge-only flag after the signin param', () => {
-        expect(getSigninDeeplink(deepLink, identityId, true)).toBe('decentraland://open?signin=anIdentityId&bridge-only=true')
+    describe('and bridgeOnly is enabled', () => {
+      it('should append the canonical bridgeOnly flag after the signin param', () => {
+        expect(getSigninDeeplink(deepLink, identityId, true)).toBe('decentraland://open?signin=anIdentityId&bridgeOnly=true')
       })
     })
 
     describe('and an authRequestId is provided', () => {
-      it('should append it verbatim after the signin and bridge-only params', () => {
+      it('should append it verbatim after the signin and bridgeOnly params', () => {
         expect(getSigninDeeplink(deepLink, identityId, true, 'abc-123')).toBe(
-          'decentraland://open?signin=anIdentityId&bridge-only=true&authRequestId=abc-123'
+          'decentraland://open?signin=anIdentityId&bridgeOnly=true&authRequestId=abc-123'
         )
       })
     })
@@ -934,15 +934,15 @@ describe('when building the signin deep link', () => {
       deepLink = 'decentraland://'
     })
 
-    describe('and bridge-only is disabled', () => {
+    describe('and bridgeOnly is disabled', () => {
       it('should append only the dclenv zone param after the signin param', () => {
         expect(getSigninDeeplink(deepLink, identityId, false)).toBe('decentraland://open?signin=anIdentityId&dclenv=zone')
       })
     })
 
-    describe('and bridge-only is enabled', () => {
-      it('should append both the dclenv zone param and the bridge-only flag after the signin param', () => {
-        expect(getSigninDeeplink(deepLink, identityId, true)).toBe('decentraland://open?signin=anIdentityId&dclenv=zone&bridge-only=true')
+    describe('and bridgeOnly is enabled', () => {
+      it('should append both the dclenv zone param and the bridgeOnly flag after the signin param', () => {
+        expect(getSigninDeeplink(deepLink, identityId, true)).toBe('decentraland://open?signin=anIdentityId&dclenv=zone&bridgeOnly=true')
       })
     })
   })

--- a/src/components/Pages/RequestPage/utils.ts
+++ b/src/components/Pages/RequestPage/utils.ts
@@ -45,9 +45,9 @@ const launchDeepLink = (url: string): Promise<boolean> => {
   })
 }
 
-// Query params every client deep link carries: dclenv on non-production environments and
-// the bridge-only flag when the auth site was opened with it.
-function getDeeplinkQueryParams(bridgeOnly?: boolean): URLSearchParams {
+// Query params every client deep link carries: dclenv on non-production environments, the
+// bridge-only flag, and the authRequestId value when the auth site was opened with them.
+function getDeeplinkQueryParams(bridgeOnly?: boolean, authRequestId?: string | null): URLSearchParams {
   const env = config.get('ENVIRONMENT').toLowerCase()
   const params = new URLSearchParams()
   if (env !== 'production') {
@@ -56,22 +56,26 @@ function getDeeplinkQueryParams(bridgeOnly?: boolean): URLSearchParams {
   if (bridgeOnly) {
     params.set('bridge-only', 'true')
   }
+  if (authRequestId) {
+    params.set('authRequestId', authRequestId)
+  }
   return params
 }
 
 // Builds the bare client deep link (e.g. after the traditional signing flow completes).
-function getExplorerDeeplink(deepLink?: string, bridgeOnly?: boolean): string {
+function getExplorerDeeplink(deepLink?: string, bridgeOnly?: boolean, authRequestId?: string | null): string {
   const base = deepLink || 'decentraland://'
-  const query = getDeeplinkQueryParams(bridgeOnly).toString()
+  const query = getDeeplinkQueryParams(bridgeOnly, authRequestId).toString()
   return query ? `${base}?${query}` : base
 }
 
 // Builds the `open?signin=<identityId>` deep link that hands a posted identity to the
-// client, carrying the same query params (dclenv, bridge-only) as the bare deep link.
-// Seeding signin into the URLSearchParams encodes the id and keeps a single `?`-joined query.
-function getSigninDeeplink(deepLink: string | undefined, identityId: string, bridgeOnly?: boolean): string {
+// client, carrying the same query params (dclenv, bridge-only, authRequestId) as the bare
+// deep link. Seeding signin into the URLSearchParams encodes the id and keeps a single
+// `?`-joined query.
+function getSigninDeeplink(deepLink: string | undefined, identityId: string, bridgeOnly?: boolean, authRequestId?: string | null): string {
   const params = new URLSearchParams({ signin: identityId })
-  getDeeplinkQueryParams(bridgeOnly).forEach((value, key) => params.set(key, value))
+  getDeeplinkQueryParams(bridgeOnly, authRequestId).forEach((value, key) => params.set(key, value))
   return `${deepLink || 'decentraland://'}open?${params.toString()}`
 }
 

--- a/src/components/Pages/RequestPage/utils.ts
+++ b/src/components/Pages/RequestPage/utils.ts
@@ -46,7 +46,7 @@ const launchDeepLink = (url: string): Promise<boolean> => {
 }
 
 // Query params every client deep link carries: dclenv on non-production environments, the
-// bridge-only flag, and the authRequestId value when the auth site was opened with them.
+// bridgeOnly flag, and the authRequestId value when the auth site was opened with them.
 function getDeeplinkQueryParams(bridgeOnly?: boolean, authRequestId?: string | null): URLSearchParams {
   const env = config.get('ENVIRONMENT').toLowerCase()
   const params = new URLSearchParams()
@@ -54,7 +54,7 @@ function getDeeplinkQueryParams(bridgeOnly?: boolean, authRequestId?: string | n
     params.set('dclenv', env === 'development' ? 'zone' : env)
   }
   if (bridgeOnly) {
-    params.set('bridge-only', 'true')
+    params.set('bridgeOnly', 'true')
   }
   if (authRequestId) {
     params.set('authRequestId', authRequestId)
@@ -70,7 +70,7 @@ function getExplorerDeeplink(deepLink?: string, bridgeOnly?: boolean, authReques
 }
 
 // Builds the `open?signin=<identityId>` deep link that hands a posted identity to the
-// client, carrying the same query params (dclenv, bridge-only, authRequestId) as the bare
+// client, carrying the same query params (dclenv, bridgeOnly, authRequestId) as the bare
 // deep link. Seeding signin into the URLSearchParams encodes the id and keeps a single
 // `?`-joined query.
 function getSigninDeeplink(deepLink: string | undefined, identityId: string, bridgeOnly?: boolean, authRequestId?: string | null): string {

--- a/src/shared/locations.spec.ts
+++ b/src/shared/locations.spec.ts
@@ -227,12 +227,12 @@ describe('locations', () => {
     })
   })
 
-  describe('when checking if bridge-only is enabled', () => {
+  describe('when checking if bridgeOnly is enabled', () => {
     let searchParams: URLSearchParams
 
-    describe('and the bridge-only param is set to "true"', () => {
+    describe('and the bridgeOnly param is set to "true"', () => {
       beforeEach(() => {
-        searchParams = new URLSearchParams('bridge-only=true')
+        searchParams = new URLSearchParams('bridgeOnly=true')
       })
 
       it('should return true', () => {
@@ -240,9 +240,9 @@ describe('locations', () => {
       })
     })
 
-    describe('and the bridge-only param is set to "true" with different casing', () => {
+    describe('and the bridgeOnly param is set to "true" with different casing', () => {
       beforeEach(() => {
-        searchParams = new URLSearchParams('bridge-only=TRUE')
+        searchParams = new URLSearchParams('bridgeOnly=TRUE')
       })
 
       it('should return true', () => {
@@ -250,9 +250,9 @@ describe('locations', () => {
       })
     })
 
-    describe('and the bridge-only param is set to "false"', () => {
+    describe('and the bridgeOnly param is set to "false"', () => {
       beforeEach(() => {
-        searchParams = new URLSearchParams('bridge-only=false')
+        searchParams = new URLSearchParams('bridgeOnly=false')
       })
 
       it('should return false', () => {
@@ -260,9 +260,9 @@ describe('locations', () => {
       })
     })
 
-    describe('and the bridge-only param is set to a non-boolean value', () => {
+    describe('and the bridgeOnly param is set to a non-boolean value', () => {
       beforeEach(() => {
-        searchParams = new URLSearchParams('bridge-only=1')
+        searchParams = new URLSearchParams('bridgeOnly=1')
       })
 
       it('should return false', () => {
@@ -270,9 +270,9 @@ describe('locations', () => {
       })
     })
 
-    describe('and the bridge-only param is present as a bare flag without an equals sign', () => {
+    describe('and the bridgeOnly param is present as a bare flag without an equals sign', () => {
       beforeEach(() => {
-        searchParams = new URLSearchParams('bridge-only')
+        searchParams = new URLSearchParams('bridgeOnly')
       })
 
       it('should return true', () => {
@@ -280,9 +280,9 @@ describe('locations', () => {
       })
     })
 
-    describe('and the bridge-only param is present with an empty value', () => {
+    describe('and the bridgeOnly param is present with an empty value', () => {
       beforeEach(() => {
-        searchParams = new URLSearchParams('bridge-only=')
+        searchParams = new URLSearchParams('bridgeOnly=')
       })
 
       it('should return true', () => {
@@ -290,7 +290,7 @@ describe('locations', () => {
       })
     })
 
-    describe('and the bridge-only param is not present', () => {
+    describe('and the bridgeOnly param is not present', () => {
       beforeEach(() => {
         searchParams = new URLSearchParams('targetConfigId=default')
       })
@@ -339,7 +339,7 @@ describe('locations', () => {
     describe('and an authRequestId is provided', () => {
       it('should append it url-encoded alongside the other preserved params', () => {
         expect(buildRequestPageUrl('request-id', 'default', { isDeepLinkFlow: true, isBridgeOnly: true, authRequestId: 'a/b c' })).toBe(
-          '/auth/requests/request-id?targetConfigId=default&flow=deeplink&bridge-only=true&authRequestId=a%2Fb%20c'
+          '/auth/requests/request-id?targetConfigId=default&flow=deeplink&bridgeOnly=true&authRequestId=a%2Fb%20c'
         )
       })
     })

--- a/src/shared/locations.spec.ts
+++ b/src/shared/locations.spec.ts
@@ -1,4 +1,11 @@
-import { extractRedirectToFromSearchParameters, extractReferrerFromSearchParameters, isBridgeOnlyEnabled, locations } from './locations'
+import {
+  buildRequestPageUrl,
+  extractRedirectToFromSearchParameters,
+  extractReferrerFromSearchParameters,
+  getAuthRequestId,
+  isBridgeOnlyEnabled,
+  locations
+} from './locations'
 
 describe('locations', () => {
   describe('login', () => {
@@ -290,6 +297,56 @@ describe('locations', () => {
 
       it('should return false', () => {
         expect(isBridgeOnlyEnabled(searchParams)).toBe(false)
+      })
+    })
+  })
+
+  describe('when getting the authRequestId', () => {
+    let searchParams: URLSearchParams
+
+    describe('and the authRequestId param is present', () => {
+      beforeEach(() => {
+        searchParams = new URLSearchParams('authRequestId=abc-123')
+      })
+
+      it('should return its value verbatim', () => {
+        expect(getAuthRequestId(searchParams)).toBe('abc-123')
+      })
+    })
+
+    describe('and the authRequestId param is present with a value needing decoding', () => {
+      beforeEach(() => {
+        searchParams = new URLSearchParams('authRequestId=a%2Fb%20c')
+      })
+
+      it('should return the decoded value', () => {
+        expect(getAuthRequestId(searchParams)).toBe('a/b c')
+      })
+    })
+
+    describe('and the authRequestId param is not present', () => {
+      beforeEach(() => {
+        searchParams = new URLSearchParams('targetConfigId=default')
+      })
+
+      it('should return null', () => {
+        expect(getAuthRequestId(searchParams)).toBeNull()
+      })
+    })
+  })
+
+  describe('when building the request page url', () => {
+    describe('and an authRequestId is provided', () => {
+      it('should append it url-encoded alongside the other preserved params', () => {
+        expect(buildRequestPageUrl('request-id', 'default', { isDeepLinkFlow: true, isBridgeOnly: true, authRequestId: 'a/b c' })).toBe(
+          '/auth/requests/request-id?targetConfigId=default&flow=deeplink&bridge-only=true&authRequestId=a%2Fb%20c'
+        )
+      })
+    })
+
+    describe('and no authRequestId is provided', () => {
+      it('should not append the authRequestId param', () => {
+        expect(buildRequestPageUrl('request-id', 'default')).toBe('/auth/requests/request-id?targetConfigId=default')
       })
     })
   })

--- a/src/shared/locations.ts
+++ b/src/shared/locations.ts
@@ -163,6 +163,13 @@ const isBridgeOnlyEnabled = (searchParams: URLSearchParams): boolean => {
   return value === '' || value === 'true'
 }
 
+// The `authRequestId` query param is an opaque value the auth site can be opened with.
+// Like `bridge-only`, it rides inside `redirectTo` to survive logins/callbacks and is
+// forwarded verbatim onto the client deep link. Returns the raw value, or null when absent.
+const AUTH_REQUEST_ID_PARAM = 'authRequestId'
+
+const getAuthRequestId = (searchParams: URLSearchParams): string | null => searchParams.get(AUTH_REQUEST_ID_PARAM)
+
 // Pseudo request id for `/auth/requests/client-login`. It has no backing auth-server
 // request: the user just logs in and the signed identity is handed to the client through
 // the `open?signin=<identityId>` deep link, mirroring the standalone mobile flow.
@@ -174,11 +181,12 @@ const CLIENT_LOGIN_REQUEST_ID = 'client-login'
 const buildRequestPageUrl = (
   requestId: string,
   targetConfigId: string,
-  options: { isDeepLinkFlow?: boolean; isBridgeOnly?: boolean } = {}
+  options: { isDeepLinkFlow?: boolean; isBridgeOnly?: boolean; authRequestId?: string | null } = {}
 ): string => {
   const flowParam = options.isDeepLinkFlow ? '&flow=deeplink' : ''
   const bridgeOnlyParam = options.isBridgeOnly ? '&bridge-only=true' : ''
-  return `/auth/requests/${requestId}?targetConfigId=${targetConfigId}${flowParam}${bridgeOnlyParam}`
+  const authRequestIdParam = options.authRequestId ? `&${AUTH_REQUEST_ID_PARAM}=${encodeURIComponent(options.authRequestId)}` : ''
+  return `/auth/requests/${requestId}?targetConfigId=${targetConfigId}${flowParam}${bridgeOnlyParam}${authRequestIdParam}`
 }
 
 export type { LoginMethod }
@@ -188,6 +196,8 @@ export {
   extractReferrerFromSearchParameters,
   isBridgeOnlyEnabled,
   BRIDGE_ONLY_PARAM,
+  getAuthRequestId,
+  AUTH_REQUEST_ID_PARAM,
   CLIENT_LOGIN_REQUEST_ID,
   buildRequestPageUrl
 }

--- a/src/shared/locations.ts
+++ b/src/shared/locations.ts
@@ -148,12 +148,12 @@ const extractReferrerFromSearchParameters = (searchParams: URLSearchParams): str
   return referrerSearchParam
 }
 
-// The `bridge-only` query param is a boolean flag the auth site can be opened with.
+// The `bridgeOnly` query param is a boolean flag the auth site can be opened with.
 // It's preserved across logins/callbacks by riding inside `redirectTo`, and when enabled
-// it's forwarded onto the client deep link. A bare flag (`?bridge-only`) or an explicit
-// `?bridge-only=true` (case-insensitive) enable it; an explicit non-true value
-// (e.g. `?bridge-only=false`) or the param being absent leave it disabled.
-const BRIDGE_ONLY_PARAM = 'bridge-only'
+// it's forwarded onto the client deep link. A bare flag (`?bridgeOnly`) or an explicit
+// `?bridgeOnly=true` (case-insensitive) enable it; an explicit non-true value
+// (e.g. `?bridgeOnly=false`) or the param being absent leave it disabled.
+const BRIDGE_ONLY_PARAM = 'bridgeOnly'
 
 const isBridgeOnlyEnabled = (searchParams: URLSearchParams): boolean => {
   if (!searchParams.has(BRIDGE_ONLY_PARAM)) {
@@ -164,7 +164,7 @@ const isBridgeOnlyEnabled = (searchParams: URLSearchParams): boolean => {
 }
 
 // The `authRequestId` query param is an opaque value the auth site can be opened with.
-// Like `bridge-only`, it rides inside `redirectTo` to survive logins/callbacks and is
+// Like `bridgeOnly`, it rides inside `redirectTo` to survive logins/callbacks and is
 // forwarded verbatim onto the client deep link. Returns the raw value, or null when absent.
 const AUTH_REQUEST_ID_PARAM = 'authRequestId'
 
@@ -184,7 +184,7 @@ const buildRequestPageUrl = (
   options: { isDeepLinkFlow?: boolean; isBridgeOnly?: boolean; authRequestId?: string | null } = {}
 ): string => {
   const flowParam = options.isDeepLinkFlow ? '&flow=deeplink' : ''
-  const bridgeOnlyParam = options.isBridgeOnly ? '&bridge-only=true' : ''
+  const bridgeOnlyParam = options.isBridgeOnly ? '&bridgeOnly=true' : ''
   const authRequestIdParam = options.authRequestId ? `&${AUTH_REQUEST_ID_PARAM}=${encodeURIComponent(options.authRequestId)}` : ''
   return `/auth/requests/${requestId}?targetConfigId=${targetConfigId}${flowParam}${bridgeOnlyParam}${authRequestIdParam}`
 }


### PR DESCRIPTION
## What

Two related query-param changes:

1. **New `authRequestId` param** — when the auth site is opened with `?authRequestId=<value>`, the value is **preserved across logins/callbacks** (it rides inside `redirectTo`) and **forwarded verbatim** onto the client deep links, alongside the `bridgeOnly` flag. It's an opaque value passed through as-is.
2. **Rename `bridge-only` → `bridgeOnly`** — aligns the existing flag with the codebase's camelCase convention for multi-word query params (`targetConfigId`, `loginMethod`, `redirectTo`, `walletError`, and the new `authRequestId`).

## Changes

- **`shared/locations.ts`** — add `AUTH_REQUEST_ID_PARAM` + `getAuthRequestId()` (returns the raw value or `null`); thread `authRequestId` through `buildRequestPageUrl`; change `BRIDGE_ONLY_PARAM` value to `bridgeOnly`.
- **`RequestPage/utils.ts`** — `getDeeplinkQueryParams`, `getExplorerDeeplink`, and `getSigninDeeplink` carry `authRequestId`; the forwarded flag key is now `bridgeOnly`.
- **`RequestPage.tsx`** — reads `authRequestId` once and passes it to every `redirectTo` / deep-link site (profile-check redirect, `toLoginPage`, completed-sign-in redirect, `SignInCompletePage`, signin deep link), deps updated.
- **`Container.tsx`** — the change-account ("Return to log in") redirect forwards `authRequestId` and uses the `bridgeOnly` key.
- **`SignInCompletePage.tsx`** — new `authRequestId` prop passed to the explorer deep link.

Only the wire string `bridge-only` → `bridgeOnly` changed; internal identifiers (`isBridgeOnlyEnabled`, `BRIDGE_ONLY_PARAM`, `isBridgeOnly`) are unchanged.

## Testing

- `tsc` + ESLint clean.
- Added parallel tests: `getAuthRequestId` + `buildRequestPageUrl` (locations.spec), the deep-link builders incl. URL-encoding (utils.spec), and RequestPage client-login forwarding (RequestPage.spec). Existing bridgeOnly tests updated to the new key.
- **Full suite: 623 tests pass** (40 suites).

## Notes

- `bridgeOnly` is a query key shared with the Explorer client and launchers. Nothing here is deployed yet, so there's no live impact — the `bridgeOnly` spelling just needs to line up with the client/launchers before launch.
- `authRequestId` is expected to be an **opaque ID** (UUID / hex / base64url). It's URL-encoded in transit so it round-trips exactly. Values containing URL-structural characters (`&`, `=`, `+`, `#`, spaces) would be affected by a pre-existing double-decode of `redirectTo` on the not-yet-logged-in path — a non-factor for opaque IDs, and out of scope here.
- Security reviewed: `authRequestId` only ever becomes a query-param value (encoded), never a scheme or HTML sink — no XSS; it rides on a fixed `/auth/requests/<id>` path with the existing same-origin `redirectTo` validation — no open redirect.
