### PR TITLE
refactor: refine the web2 approval simulation ui

### DIFF
--- a/src/components/Pages/RequestPage/RequestPage.spec.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.spec.tsx
@@ -849,6 +849,20 @@ describe('RequestPage', () => {
       await waitFor(() => expect(mockSimulateTransaction).toHaveBeenCalled())
     })
 
+    it('should reuse the prefetched meta-transaction check on approve instead of re-checking', async () => {
+      mockWalletRequest.mockResolvedValue('0xhash')
+      mockSendSuccessfulOutcome.mockResolvedValue({})
+      renderRequestPage()
+      await screen.findByTestId('wallet-interaction')
+      await waitFor(() => expect(mockCheckMetaTransactionSupport).toHaveBeenCalled())
+      const callsAfterPrefetch = mockCheckMetaTransactionSupport.mock.calls.length
+
+      await userEvent.click(screen.getByTestId('wallet-interaction-approve'))
+      await screen.findByTestId('wallet-interaction-complete')
+
+      expect(mockCheckMetaTransactionSupport.mock.calls.length).toBe(callsAfterPrefetch)
+    })
+
     describe('and the simulation request fails', () => {
       beforeEach(() => {
         mockSimulateTransaction.mockRejectedValue(new Error('tenderly down'))

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -172,6 +172,9 @@ export const RequestPage = () => {
   // Guards against re-entrant approvals (e.g. a fast double-click on the confirm dialog),
   // which would otherwise fire two transactions before `isLoading` re-renders the buttons.
   const isApprovingRef = useRef(false)
+  // Caches the meta-transaction support check from the prefetch so the approve path can reuse it
+  // for the same contract instead of repeating the (potentially networked) lookup.
+  const metaTxCheckRef = useRef<{ address: string; willUseMetaTransaction: boolean; contractName: ContractName | null } | null>(null)
   // Shares the in-flight identity POST across effect re-runs so the client-login flow
   // creates the identity exactly once; cleared on failure so a retry can re-post.
   const clientLoginPromiseRef = useRef<Promise<IdentityResponse> | null>(null)
@@ -580,7 +583,9 @@ export const RequestPage = () => {
                   setSimulationState({ status: 'loading' })
                 }
                 checkMetaTransactionSupport(contractAddress)
-                  .then(({ willUseMetaTransaction }) => {
+                  .then(({ willUseMetaTransaction, contractName }) => {
+                    // Cache the result so the approve path doesn't repeat the lookup for this tx.
+                    metaTxCheckRef.current = { address: contractAddress.toLowerCase(), willUseMetaTransaction, contractName }
                     if (cancelled) return undefined
                     setIsMetaTransaction(willUseMetaTransaction)
                     if (canShowSimulation && txParams) {
@@ -624,7 +629,7 @@ export const RequestPage = () => {
             // preview of what they are signing. Meta-transaction typed data additionally gets
             // the asset-change summary by simulating the inner call.
             if (canShowSimulation && isSignatureMethod(request.method)) {
-              const payload = extractSignaturePayload(request.method, request.params)
+              const payload = extractSignaturePayload(request.method, request.params, signerAddress)
               setSignaturePayload(payload)
               if (payload?.kind === 'typedData') {
                 const metaTx = decodeMetaTransactionTypedData(payload.typedData)
@@ -890,8 +895,11 @@ export const RequestPage = () => {
           throw new Error(`Contract address not found in transaction parameters. Received params: ${JSON.stringify(txParams ?? null)}`)
         }
 
-        // Check if this contract will use meta transactions
-        const { willUseMetaTransaction, contractName } = await checkMetaTransactionSupport(toAddress)
+        // Check if this contract will use meta transactions, reusing the prefetch result for the
+        // same contract when available to avoid repeating the lookup.
+        const cachedCheck = metaTxCheckRef.current
+        const { willUseMetaTransaction, contractName } =
+          cachedCheck && cachedCheck.address === toAddress.toLowerCase() ? cachedCheck : await checkMetaTransactionSupport(toAddress)
         if (willUseMetaTransaction && contractName) {
           const connectedProvider = await getConnectedProvider()
           if (!connectedProvider) {

--- a/src/components/Pages/RequestPage/Views/SignatureRequest/SignatureRequestView.spec.tsx
+++ b/src/components/Pages/RequestPage/Views/SignatureRequest/SignatureRequestView.spec.tsx
@@ -201,8 +201,11 @@ describe('when rendering the SignatureRequestView', () => {
           onApprove={onApprove}
         />
       )
-      await userEvent.click(screen.getByText('request.signature.view_raw'))
+      const toggle = screen.getByText('request.signature.view_raw')
+      expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      await userEvent.click(toggle)
       expect(screen.getByTestId('signature-raw')).toBeInTheDocument()
+      expect(screen.getByText('request.signature.hide_raw')).toHaveAttribute('aria-expanded', 'true')
     })
 
     it('should keep approval disabled while the meta-transaction simulation is loading', () => {

--- a/src/components/Pages/RequestPage/Views/SignatureRequest/SignatureRequestView.tsx
+++ b/src/components/Pages/RequestPage/Views/SignatureRequest/SignatureRequestView.tsx
@@ -70,7 +70,7 @@ export const SignatureRequestView = ({
               verifiedContracts={verifiedContracts}
               chainId={chainId}
             />
-            <RawToggle type="button" onClick={() => setShowRaw(show => !show)}>
+            <RawToggle type="button" aria-expanded={showRaw} onClick={() => setShowRaw(show => !show)}>
               {showRaw ? t('request.signature.hide_raw') : t('request.signature.view_raw')}
             </RawToggle>
             {showRaw ? <MessageBlock data-testid="signature-raw">{payload.raw}</MessageBlock> : null}

--- a/src/components/Pages/RequestPage/Views/SimulationSummary/SimulationSummary.spec.tsx
+++ b/src/components/Pages/RequestPage/Views/SimulationSummary/SimulationSummary.spec.tsx
@@ -238,6 +238,38 @@ describe('when rendering the SimulationSummary', () => {
     })
   })
 
+  describe('and an asset change involves neither the user as sender nor recipient', () => {
+    beforeEach(() => {
+      const result = emptyResult({
+        assetChanges: [
+          {
+            type: 'transfer',
+            standard: 'erc20',
+            from: '0x1111111111111111111111111111111111111111',
+            to: '0x2222222222222222222222222222222222222222',
+            amount: '5',
+            rawAmount: '5000000000000000000',
+            tokenId: null,
+            contractAddress: '0x0f5d2fb29fb7d3cfee444a200298f468908cc942',
+            symbol: 'MANA',
+            name: 'Decentraland MANA',
+            decimals: 18,
+            logoUrl: null,
+            dollarValue: null
+          }
+        ]
+      })
+      simulation = { status: 'ready', result }
+    })
+
+    it('should not present the third-party movement as sent or received', () => {
+      render(<SimulationSummary simulation={simulation} userAddress={USER} />)
+      expect(screen.queryByText('request.transaction_dialog.you_send')).not.toBeInTheDocument()
+      expect(screen.queryByText('request.transaction_dialog.you_receive')).not.toBeInTheDocument()
+      expect(screen.getByText('request.transaction_dialog.no_changes')).toBeInTheDocument()
+    })
+  })
+
   describe('and an ApprovalForAll is revoked', () => {
     beforeEach(() => {
       const result = emptyResult({

--- a/src/components/Pages/RequestPage/Views/SimulationSummary/SimulationSummary.spec.tsx
+++ b/src/components/Pages/RequestPage/Views/SimulationSummary/SimulationSummary.spec.tsx
@@ -374,6 +374,30 @@ describe('when rendering the SimulationSummary', () => {
     })
   })
 
+  describe('and the net value is a large exponential the numeric fallback cannot group', () => {
+    beforeEach(() => {
+      simulation = { status: 'ready', result: emptyResult({ balanceChanges: [{ address: USER, dollarValue: '1.5e+21' }] }) }
+    })
+
+    it('should omit the net change rather than render a malformed amount', () => {
+      render(<SimulationSummary simulation={simulation} userAddress={USER} />)
+      expect(screen.queryByText('request.transaction_dialog.net_change')).not.toBeInTheDocument()
+      expect(screen.queryByText(/e\+21/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('and a tiny negative net value in scientific notation rounds to zero', () => {
+    beforeEach(() => {
+      simulation = { status: 'ready', result: emptyResult({ balanceChanges: [{ address: USER, dollarValue: '-1e-9' }] }) }
+    })
+
+    it('should not render it as a negative amount', () => {
+      render(<SimulationSummary simulation={simulation} userAddress={USER} />)
+      expect(screen.getByText('+$0.00')).toBeInTheDocument()
+      expect(screen.queryByText('-$0.00')).not.toBeInTheDocument()
+    })
+  })
+
   describe('and the transaction moves no assets and grants no approvals', () => {
     beforeEach(() => {
       simulation = { status: 'ready', result: emptyResult() }

--- a/src/components/Pages/RequestPage/Views/SimulationSummary/SimulationSummary.spec.tsx
+++ b/src/components/Pages/RequestPage/Views/SimulationSummary/SimulationSummary.spec.tsx
@@ -72,9 +72,9 @@ describe('when rendering the SimulationSummary', () => {
       simulation = { status: 'loading' }
     })
 
-    it('should render the gas footer alongside the skeleton', () => {
+    it('should not render the gas footer yet (the gas-covered state may be unresolved while loading)', () => {
       render(<SimulationSummary simulation={simulation} userAddress={USER} gas={{ covered: false, cost: '0.0025', balance: '1.5' }} />)
-      expect(screen.getByText(/transaction_cost 0.0025/)).toBeInTheDocument()
+      expect(screen.queryByText(/transaction_cost/)).not.toBeInTheDocument()
     })
   })
 
@@ -339,6 +339,41 @@ describe('when rendering the SimulationSummary', () => {
     })
   })
 
+  describe('and the net dollar value has a very large integer part', () => {
+    beforeEach(() => {
+      // Number(...) would round this past ~15 significant digits; the string-based formatter must not.
+      simulation = { status: 'ready', result: emptyResult({ balanceChanges: [{ address: USER, dollarValue: '1234567890123456.789' }] }) }
+    })
+
+    it('should render the exact grouped amount without precision loss', () => {
+      render(<SimulationSummary simulation={simulation} userAddress={USER} />)
+      expect(screen.getByText('+$1,234,567,890,123,456.79')).toBeInTheDocument()
+    })
+  })
+
+  describe('and the net dollar value is in scientific notation', () => {
+    beforeEach(() => {
+      simulation = { status: 'ready', result: emptyResult({ balanceChanges: [{ address: USER, dollarValue: '1e-8' }] }) }
+    })
+
+    it('should still render it via the numeric fallback rather than dropping it', () => {
+      render(<SimulationSummary simulation={simulation} userAddress={USER} />)
+      expect(screen.getByText('+$0.00')).toBeInTheDocument()
+    })
+  })
+
+  describe('and a tiny negative net value rounds to zero', () => {
+    beforeEach(() => {
+      simulation = { status: 'ready', result: emptyResult({ balanceChanges: [{ address: USER, dollarValue: '-0.001' }] }) }
+    })
+
+    it('should not render it as a negative amount', () => {
+      render(<SimulationSummary simulation={simulation} userAddress={USER} />)
+      expect(screen.getByText('+$0.00')).toBeInTheDocument()
+      expect(screen.queryByText('-$0.00')).not.toBeInTheDocument()
+    })
+  })
+
   describe('and the transaction moves no assets and grants no approvals', () => {
     beforeEach(() => {
       simulation = { status: 'ready', result: emptyResult() }
@@ -363,6 +398,30 @@ describe('when rendering the SimulationSummary', () => {
       expect(screen.queryByTestId('simulation-events')).not.toBeInTheDocument()
       await userEvent.click(screen.getByText('request.transaction_dialog.technical_details'))
       expect(screen.getByTestId('simulation-events')).toBeInTheDocument()
+    })
+
+    it('should reflect the open state on the toggle for assistive tech', async () => {
+      render(<SimulationSummary simulation={simulation} userAddress={USER} />)
+      const toggle = screen.getByRole('button')
+      expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      await userEvent.click(toggle)
+      expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    })
+  })
+
+  describe('and there are more events than the display cap', () => {
+    beforeEach(() => {
+      const events = Array.from({ length: 150 }, (_, index) => ({
+        name: `Event${index}`,
+        address: '0x0f5d2fb29fb7d3cfee444a200298f468908cc942'
+      }))
+      simulation = { status: 'ready', result: emptyResult({ events }) }
+    })
+
+    it('should cap the rendered event rows at the defensive maximum', async () => {
+      render(<SimulationSummary simulation={simulation} userAddress={USER} />)
+      await userEvent.click(screen.getByText('request.transaction_dialog.technical_details'))
+      expect(screen.getByTestId('simulation-events').children).toHaveLength(100)
     })
   })
 

--- a/src/components/Pages/RequestPage/Views/SimulationSummary/SimulationSummary.tsx
+++ b/src/components/Pages/RequestPage/Views/SimulationSummary/SimulationSummary.tsx
@@ -90,13 +90,14 @@ const formatUsd = (dollarValue: string | null, signed = false): string | null =>
   const value = Number(dollarValue)
   if (!Number.isFinite(value)) return null
   const fixed = Math.abs(value).toFixed(2)
-  // toFixed switches to exponential for |value| >= 1e21, which can't be grouped cleanly; skip it
-  // rather than render a malformed amount.
-  if (!fixed.includes('.')) return null
+  // toFixed switches to exponential notation for very large magnitudes (e.g. "1.5e+21"), which
+  // can't be grouped cleanly; skip those rather than render a malformed amount.
+  if (/e/i.test(fixed)) return null
   const [intPart, decPart] = fixed.split('.')
   const magnitude = `$${groupThousands(intPart)}.${decPart}`
   if (!signed) return magnitude
-  return `${value < 0 ? '-' : '+'}${magnitude}`
+  // Only mark as negative when the rounded value is actually non-zero (mirrors the decimal path).
+  return `${value < 0 && Number(fixed) !== 0 ? '-' : '+'}${magnitude}`
 }
 
 const assetTitle = (change: AssetChange, t: Translate): string => {

--- a/src/components/Pages/RequestPage/Views/SimulationSummary/SimulationSummary.tsx
+++ b/src/components/Pages/RequestPage/Views/SimulationSummary/SimulationSummary.tsx
@@ -360,11 +360,12 @@ export const SimulationSummary = ({
 
   const { result } = simulation
   const user = userAddress.toLowerCase()
-  // "Sends" are assets leaving the user's account (transfers out, and burns whose `from` is
-  // the user). Everything else (assets received, mints to the user, and effects where the
-  // user is neither party) is grouped under "receives".
+  // "Sends" are assets leaving the user's account (transfers out, and burns whose `from` is the
+  // user). "Receives" are assets arriving to the user (transfers in and mints whose `to` is the
+  // user). A change where the user is neither party isn't shown as either, so an unrelated
+  // third-party movement is never mislabelled as something the user receives.
   const sends = result.assetChanges.filter(change => change.from?.toLowerCase() === user)
-  const receives = result.assetChanges.filter(change => change.from?.toLowerCase() !== user)
+  const receives = result.assetChanges.filter(change => change.from?.toLowerCase() !== user && change.to?.toLowerCase() === user)
   const hasNoChanges = sends.length === 0 && receives.length === 0 && result.approvalChanges.length === 0
   const networkName = getNetworkName(chainId)
 

--- a/src/components/Pages/RequestPage/Views/SimulationSummary/SimulationSummary.tsx
+++ b/src/components/Pages/RequestPage/Views/SimulationSummary/SimulationSummary.tsx
@@ -36,6 +36,10 @@ import {
 
 type Translate = (key: string, opts?: Record<string, string | number>) => string
 
+// Defensive ceiling on decoded events rendered in the technical-details section. The server already
+// caps events at 50; this guards the UI against an unexpectedly large or malformed response.
+const MAX_DISPLAYED_EVENTS = 100
+
 const shortenAddress = (address: string | null): string => {
   if (!address) return ''
   return address.length > 12 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address
@@ -62,9 +66,34 @@ const formatTokenAmount = (raw: string): string => {
 
 const formatUsd = (dollarValue: string | null, signed = false): string | null => {
   if (dollarValue === null) return null
+  // Parse and round from the plain-decimal string (rather than through Number) so a very large
+  // integer part is never rounded away. Round half-up to cents, carrying with BigInt. Inputs that
+  // aren't plain decimals (e.g. scientific notation) fall back to the Number-based path below.
+  const match = /^(-?)(\d+)(?:\.(\d+))?$/.exec(dollarValue.trim())
+  if (match) {
+    const [, sign, intPart, fracPart = ''] = match
+    let cents = Number((fracPart + '00').slice(0, 2))
+    if ((fracPart[2] ?? '0') >= '5') cents += 1
+    let intValue = BigInt(intPart)
+    if (cents === 100) {
+      cents = 0
+      intValue += 1n
+    }
+    const magnitude = `$${groupThousands(intValue.toString())}.${String(cents).padStart(2, '0')}`
+    if (!signed) return magnitude
+    // Only mark as negative when the rounded value is actually non-zero, so a tiny negative that
+    // rounds to zero doesn't render as a misleading "-$0.00".
+    const isNegative = sign === '-' && !(intValue === 0n && cents === 0)
+    return `${isNegative ? '-' : '+'}${magnitude}`
+  }
+
   const value = Number(dollarValue)
   if (!Number.isFinite(value)) return null
-  const [intPart, decPart] = Math.abs(value).toFixed(2).split('.')
+  const fixed = Math.abs(value).toFixed(2)
+  // toFixed switches to exponential for |value| >= 1e21, which can't be grouped cleanly; skip it
+  // rather than render a malformed amount.
+  if (!fixed.includes('.')) return null
+  const [intPart, decPart] = fixed.split('.')
   const magnitude = `$${groupThousands(intPart)}.${decPart}`
   if (!signed) return magnitude
   return `${value < 0 ? '-' : '+'}${magnitude}`
@@ -277,14 +306,15 @@ const TechnicalDetails = ({
 }) => {
   const [open, setOpen] = useState(false)
   if (events.length === 0) return null
+  const displayedEvents = events.slice(0, MAX_DISPLAYED_EVENTS)
   return (
     <>
-      <Toggle type="button" onClick={() => setOpen(show => !show)}>
+      <Toggle type="button" aria-expanded={open} onClick={() => setOpen(show => !show)}>
         {open ? t('request.transaction_dialog.hide_technical_details') : t('request.transaction_dialog.technical_details')}
       </Toggle>
       {open ? (
         <EventList data-testid="simulation-events">
-          {events.map((event, index) => (
+          {displayedEvents.map((event, index) => (
             <EventRow key={`event-${index}`}>
               {event.name || t('request.transaction_dialog.event_unknown')} ·{' '}
               <AddressLink
@@ -313,8 +343,10 @@ export const SimulationSummary = ({
   const verified = new Set(verifiedContracts.map(address => address.toLowerCase()))
 
   // The gas footer comes from the wallet/meta-transaction check, not the Tenderly result, so it is
-  // shown in every non-idle state — including when the preview is still loading or unavailable — so
-  // the user always sees the gas cost (or that gas is covered) before approving.
+  // shown once the preview resolves (ready or unavailable) so the user always sees the gas cost (or
+  // that gas is covered) before approving. It is intentionally omitted while loading, because the
+  // meta-transaction check that determines "gas covered" may not have resolved yet — and approval
+  // is disabled during loading regardless.
   const gasFooter = gas ? (
     <GasFooter>
       {gas.covered ? (
@@ -342,7 +374,6 @@ export const SimulationSummary = ({
             </ChangeText>
           </SkeletonRow>
         ))}
-        {gasFooter}
       </Root>
     )
   }

--- a/src/components/Pages/RequestPage/utils.spec.ts
+++ b/src/components/Pages/RequestPage/utils.spec.ts
@@ -1059,6 +1059,32 @@ describe('when testing extractSignaturePayload', () => {
     })
   })
 
+  describe('and the signer address is provided to disambiguate', () => {
+    describe('and personal_sign passes the message first and the signer second', () => {
+      it('should treat the first element as the message', () => {
+        const result = extractSignaturePayload('personal_sign', ['gm', userAddress], userAddress)
+        expect(result).toEqual({ kind: 'message', message: 'gm' })
+      })
+    })
+
+    describe('and eth_sign passes the signer first and the message second', () => {
+      it('should treat the second element as the message', () => {
+        const result = extractSignaturePayload('eth_sign', [userAddress, 'sign me'], userAddress)
+        expect(result).toEqual({ kind: 'message', message: 'sign me' })
+      })
+    })
+
+    describe('and the hex-encoded message is itself address-shaped', () => {
+      it('should decode the message rather than mistaking it for the signer address', () => {
+        // A 20-byte message hex-encodes to `0x` + 40 hex chars, which matches the address shape;
+        // matching the known signer keeps it correctly classified as the message.
+        const hexMessage = '0x' + '61'.repeat(20) // 20 bytes of 'a'
+        const result = extractSignaturePayload('personal_sign', [hexMessage, userAddress], userAddress)
+        expect(result).toEqual({ kind: 'message', message: 'a'.repeat(20) })
+      })
+    })
+  })
+
   describe('and no params are provided', () => {
     it('should return null', () => {
       expect(extractSignaturePayload('personal_sign', undefined)).toBeNull()

--- a/src/components/Pages/RequestPage/utils.ts
+++ b/src/components/Pages/RequestPage/utils.ts
@@ -41,18 +41,29 @@ function isKnownDecentralandContract(address: string): boolean {
  * Extracts what a signature request asks the user to sign: a plain message (decoding
  * hex-encoded UTF-8 when possible) or an EIP-712 typed-data structure. Returns null when the
  * payload can't be interpreted.
+ *
+ * `signerAddress` (the connected account) is used to tell the message apart from the address
+ * parameter: personal_sign is [message, address] and eth_sign is [address, message], but the
+ * ordering isn't consistent across providers. Matching the known signer is robust even when the
+ * message itself happens to look like an address; when no signer is available we fall back to a
+ * shape heuristic (treat a leading address-shaped value as the address).
  */
-function extractSignaturePayload(method: string, params: unknown[] | undefined): SignaturePayload | null {
+function extractSignaturePayload(method: string, params: unknown[] | undefined, signerAddress?: string): SignaturePayload | null {
   if (!params || params.length === 0) return null
   const normalizedMethod = method.toLowerCase()
 
   if (normalizedMethod === 'personal_sign' || normalizedMethod === 'eth_sign') {
-    // personal_sign is [message, address]; eth_sign is [address, message]. Pick the element
-    // that is not a bare address as the message.
     const [first, second] = params
+    const signer = signerAddress?.toLowerCase()
     let message: unknown = first
-    if (typeof first === 'string' && ADDRESS_REGEX.test(first) && typeof second === 'string') {
-      message = second
+    if (typeof first === 'string' && typeof second === 'string') {
+      if (signer && first.toLowerCase() === signer) {
+        message = second
+      } else if (signer && second.toLowerCase() === signer) {
+        message = first
+      } else if (ADDRESS_REGEX.test(first)) {
+        message = second
+      }
     }
     if (typeof message !== 'string') return null
 


### PR DESCRIPTION
follow-up refinements to the web2 (magic/thirdweb) transaction-simulation and signature-preview ui shipped in #422. no behaviour change for external-wallet users; simulation still fails open and never blocks approval.

## changes

- **disambiguate signature messages by the connected signer.** `extractSignaturePayload` now matches the known signer address to tell the message from the address param instead of a shape heuristic, so a message that happens to be address-shaped is no longer mistaken for the signer. falls back to the previous heuristic when no signer is available.
- **group received assets precisely.** an asset change counts as received only when the user is the recipient (`to === user`), so an unrelated third-party movement is never shown as something the user receives.
- **dedupe the meta-transaction support check.** the result from the prefetch is cached and reused on the approve path for the same contract, avoiding a repeated (possibly networked) lookup.
- **hide the gas footer while the preview is loading.** it renders once the preview resolves (ready or unavailable) so it can't briefly show a stale gas figure before the meta-transaction check resolves; approval is disabled during loading regardless.
- **format usd values losslessly.** parse the decimal string with bigint cent rounding so a very large integer part is never rounded away, with a numeric fallback for non-decimal inputs, and avoid a misleading "-$0.00" for tiny negatives that round to zero.
- **cap technical-detail events** at a defensive client ceiling above the server's own cap, guarding against an oversized or malformed response.
- **announce disclosure state** — `aria-expanded` on the technical-details and raw-payload toggles.

## testing

- `tsc` clean, prettier clean, eslint clean on changed files.
- 938 tests pass across the request-page and auth areas, including new regression tests for each change (signer disambiguation incl. an address-shaped message, third-party grouping, meta-tx dedupe, gas hidden while loading, lossless/large/scientific/negative-zero usd formatting, event cap, and toggle aria state).
- two adversarial review passes found no correctness bugs or approval-blocking regressions; the three low/cosmetic items they raised are addressed here.

## not included

the `npm run lint` tooling gap (it reports pre-existing errors on main and skips `.tsx`) is a separate eslint-9 flat-config migration and is intentionally left for its own pr.
