### PR TITLE
fix: improve deep-link launch detection

### DIFF
--- a/src/components/Pages/RequestPage/launchDeepLink.spec.ts
+++ b/src/components/Pages/RequestPage/launchDeepLink.spec.ts
@@ -1,0 +1,128 @@
+import { isMobile } from '../LoginPage/utils'
+import { launchDeepLink } from './utils'
+
+jest.mock('../LoginPage/utils', () => ({
+  isMobile: jest.fn()
+}))
+
+describe('when launching a deep link', () => {
+  let deepLinkUrl: string
+
+  beforeEach(() => {
+    deepLinkUrl = 'decentraland://open?signin=anIdentityId'
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.resetAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  describe('and the browser window loses focus', () => {
+    let launchPromise: Promise<boolean>
+
+    beforeEach(() => {
+      jest.mocked(isMobile).mockReturnValueOnce(false)
+      launchPromise = launchDeepLink(deepLinkUrl)
+      window.dispatchEvent(new Event('blur'))
+    })
+
+    it('should report that the application was launched', async () => {
+      await expect(launchPromise).resolves.toBe(true)
+    })
+
+    it('should remove the deep-link iframe', async () => {
+      await launchPromise
+      expect(document.querySelector(`iframe[src="${deepLinkUrl}"]`)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('and the page becomes hidden', () => {
+    let launchPromise: Promise<boolean>
+    let originalVisibilityState: PropertyDescriptor | undefined
+
+    beforeEach(() => {
+      originalVisibilityState = Object.getOwnPropertyDescriptor(document, 'visibilityState')
+      Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' })
+      jest.mocked(isMobile).mockReturnValueOnce(false)
+      launchPromise = launchDeepLink(deepLinkUrl)
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    afterEach(() => {
+      if (originalVisibilityState) {
+        Object.defineProperty(document, 'visibilityState', originalVisibilityState)
+      } else {
+        delete (document as unknown as { visibilityState?: DocumentVisibilityState }).visibilityState
+      }
+    })
+
+    it('should report that the application was launched', async () => {
+      await expect(launchPromise).resolves.toBe(true)
+    })
+  })
+
+  describe('and the page is unloaded', () => {
+    let launchPromise: Promise<boolean>
+
+    beforeEach(() => {
+      jest.mocked(isMobile).mockReturnValueOnce(false)
+      launchPromise = launchDeepLink(deepLinkUrl)
+      window.dispatchEvent(new Event('pagehide'))
+    })
+
+    it('should report that the application was launched', async () => {
+      await expect(launchPromise).resolves.toBe(true)
+    })
+  })
+
+  describe('and no application-launch signal is received', () => {
+    let launchPromise: Promise<boolean>
+
+    beforeEach(() => {
+      jest.useFakeTimers()
+      jest.mocked(isMobile).mockReturnValueOnce(false)
+      launchPromise = launchDeepLink(deepLinkUrl)
+      jest.advanceTimersByTime(5000)
+    })
+
+    it('should report that the application was not launched', async () => {
+      await expect(launchPromise).resolves.toBe(false)
+    })
+
+    it('should remove the deep-link iframe', async () => {
+      await launchPromise
+      expect(document.querySelector(`iframe[src="${deepLinkUrl}"]`)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('and the browser is running on mobile', () => {
+    let launchPromise: Promise<boolean>
+    let originalLocation: Location
+
+    beforeEach(() => {
+      originalLocation = window.location
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: { ...originalLocation, href: '' }
+      })
+      jest.mocked(isMobile).mockReturnValueOnce(true)
+      launchPromise = launchDeepLink(deepLinkUrl)
+    })
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: originalLocation
+      })
+    })
+
+    it('should navigate directly to the deep link', () => {
+      expect(window.location.href).toBe(deepLinkUrl)
+    })
+
+    it('should report that the application was launched', async () => {
+      await expect(launchPromise).resolves.toBe(true)
+    })
+  })
+})

--- a/src/components/Pages/RequestPage/launchDeepLink.spec.ts
+++ b/src/components/Pages/RequestPage/launchDeepLink.spec.ts
@@ -76,6 +76,65 @@ describe('when launching a deep link', () => {
     })
   })
 
+  describe('and multiple application-launch signals are received', () => {
+    let launchPromise: Promise<boolean>
+    let removeIframeSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      jest.mocked(isMobile).mockReturnValueOnce(false)
+      launchPromise = launchDeepLink(deepLinkUrl)
+      const iframe = document.querySelector(`iframe[src="${deepLinkUrl}"]`) as HTMLIFrameElement
+      removeIframeSpy = jest.spyOn(iframe, 'remove')
+      window.dispatchEvent(new Event('blur'))
+      window.dispatchEvent(new Event('pagehide'))
+    })
+
+    afterEach(() => {
+      removeIframeSpy.mockRestore()
+    })
+
+    it('should report that the application was launched', async () => {
+      await expect(launchPromise).resolves.toBe(true)
+    })
+
+    it('should clean up the launch attempt only once', async () => {
+      await launchPromise
+      expect(removeIframeSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('and a visibility change leaves the page visible', () => {
+    let launchPromise: Promise<boolean>
+    let onSettled: jest.Mock
+    let originalVisibilityState: PropertyDescriptor | undefined
+
+    beforeEach(() => {
+      jest.useFakeTimers()
+      originalVisibilityState = Object.getOwnPropertyDescriptor(document, 'visibilityState')
+      Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
+      jest.mocked(isMobile).mockReturnValueOnce(false)
+      onSettled = jest.fn()
+      launchPromise = launchDeepLink(deepLinkUrl)
+      void launchPromise.then(onSettled)
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    afterEach(async () => {
+      jest.advanceTimersByTime(5000)
+      await launchPromise
+      if (originalVisibilityState) {
+        Object.defineProperty(document, 'visibilityState', originalVisibilityState)
+      } else {
+        delete (document as unknown as { visibilityState?: DocumentVisibilityState }).visibilityState
+      }
+    })
+
+    it('should keep waiting for an application-launch signal', async () => {
+      await Promise.resolve()
+      expect(onSettled).not.toHaveBeenCalled()
+    })
+  })
+
   describe('and no application-launch signal is received', () => {
     let launchPromise: Promise<boolean>
 

--- a/src/components/Pages/RequestPage/utils.ts
+++ b/src/components/Pages/RequestPage/utils.ts
@@ -196,11 +196,14 @@ function buildSendTransactionSimulationPayload(
   }
 }
 
-const DEEPLINK_DETECTION_TIMEOUT = 500
+// Native-protocol confirmation dialogs need enough time for the user to react. A 500 ms window
+// produced false negatives: the timeout could render the failure view while the browser prompt
+// was still open, and the app would then launch after the user accepted it.
+const DEEPLINK_DETECTION_TIMEOUT = 5000
 
 /**
  * Attempts to launch a deep link and detects if the app handled it.
- * Uses blur detection technique - if window loses focus, app was launched.
+ * Uses browser lifecycle signals to infer that control was handed to the app.
  * Returns true if app was detected, false otherwise.
  */
 const launchDeepLink = (url: string): Promise<boolean> => {
@@ -211,26 +214,42 @@ const launchDeepLink = (url: string): Promise<boolean> => {
       return
     }
 
-    let appDetected = false
-
-    const handleBlur = () => {
-      appDetected = true
-    }
-
-    window.addEventListener('blur', handleBlur)
-
     // Create a hidden iframe to trigger the deep link
     // This avoids Safari redirecting to an invalid URL if app is not installed
     const iframe = document.createElement('iframe')
     iframe.setAttribute('style', 'display: none')
     iframe.src = url
-    document.body.appendChild(iframe)
 
-    setTimeout(() => {
-      window.removeEventListener('blur', handleBlur)
-      document.body.removeChild(iframe)
-      resolve(appDetected)
-    }, DEEPLINK_DETECTION_TIMEOUT)
+    let settled = false
+
+    const cleanup = () => {
+      window.removeEventListener('blur', handleAppLaunch)
+      window.removeEventListener('pagehide', handleAppLaunch)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      clearTimeout(timeoutId)
+      iframe.remove()
+    }
+
+    const settle = (wasLaunched: boolean) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(wasLaunched)
+    }
+
+    const handleAppLaunch = () => settle(true)
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        settle(true)
+      }
+    }
+
+    window.addEventListener('blur', handleAppLaunch)
+    window.addEventListener('pagehide', handleAppLaunch)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    const timeoutId = setTimeout(() => settle(false), DEEPLINK_DETECTION_TIMEOUT)
+    document.body.appendChild(iframe)
   })
 }
 

--- a/src/components/Pages/RequestPage/utils.ts
+++ b/src/components/Pages/RequestPage/utils.ts
@@ -221,12 +221,17 @@ const launchDeepLink = (url: string): Promise<boolean> => {
     iframe.src = url
 
     let settled = false
+    // Initialized separately so cleanup never closes over a binding in its temporal dead zone.
+    // This also keeps cleanup safe if a future refactor can settle before the timer is armed.
+    let timeoutId: ReturnType<typeof setTimeout> | undefined = undefined
 
     const cleanup = () => {
       window.removeEventListener('blur', handleAppLaunch)
       window.removeEventListener('pagehide', handleAppLaunch)
       document.removeEventListener('visibilitychange', handleVisibilityChange)
-      clearTimeout(timeoutId)
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId)
+      }
       iframe.remove()
     }
 
@@ -248,7 +253,7 @@ const launchDeepLink = (url: string): Promise<boolean> => {
     window.addEventListener('pagehide', handleAppLaunch)
     document.addEventListener('visibilitychange', handleVisibilityChange)
 
-    const timeoutId = setTimeout(() => settle(false), DEEPLINK_DETECTION_TIMEOUT)
+    timeoutId = setTimeout(() => settle(false), DEEPLINK_DETECTION_TIMEOUT)
     document.body.appendChild(iframe)
   })
 }


### PR DESCRIPTION
## Summary
- extend the desktop deep-link detection window from 500 ms to 5 seconds so users can respond to the native-app prompt
- detect successful handoff through blur, visibilitychange, and pagehide lifecycle signals
- clean up listeners, timers, and the hidden iframe after detection settles
- add direct unit coverage for each desktop signal, timeout cleanup, and mobile navigation

## Problem
The previous detector treated the absence of window blur within 500 ms as a launch failure. Native-protocol prompts can remain open longer than that, causing the page to show an application-opening error even though the app opens after the user accepts the prompt.

## Validation
- TypeScript: ./node_modules/.bin/tsc --noEmit
- ESLint: changed files pass
- Jest: 22 focused tests pass
- git diff --check