### PR TITLE
fix: security & correctness hardening across the auth flows

### DIFF
--- a/src/components/Pages/AvatarSetupPage/AvatarSetupPage.tsx
+++ b/src/components/Pages/AvatarSetupPage/AvatarSetupPage.tsx
@@ -88,6 +88,7 @@ const AvatarSetupPage: React.FC = () => {
     showWearablePreview: false,
     isTermsChecked: sessionStorage.getItem('dcl_avatar_setup_is_terms_checked') === 'true' || false,
     isEmailInherited: false,
+    subscribeNewsletter: false,
     hasWearablePreviewLoaded: false
   })
 
@@ -96,6 +97,10 @@ const AvatarSetupPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null)
 
   const isProcessingMessageRef = useRef(false)
+  // Guards the "reached the avatar creator" analytics (TOS success + CP3-completed / CP4-reached)
+  // so they fire exactly once. handleContinueClick runs again on every retry click after a preview
+  // error, which would otherwise inflate the onboarding funnel counts.
+  const hasTrackedAvatarCreatorRef = useRef(false)
 
   const [isAvatarParticlesAnimationEnded, setIsAvatarParticlesAnimationEnded] = useState(false)
 
@@ -184,8 +189,14 @@ const AvatarSetupPage: React.FC = () => {
         const wearablePreviewController = WearablePreview.createController('avatar-preview-configurator')
         await wearablePreviewController.scene.setUsername(state.username)
 
-        // Only track once the preview is loaded to avoid double-firing,
-        // since this function runs twice (on click + on preview load).
+        // Track once, after the preview command succeeds. This function runs twice per attempt
+        // (on click + on preview load) and again on every retry click after an error; the ref
+        // ensures the funnel events fire exactly once.
+        if (hasTrackedAvatarCreatorRef.current) {
+          return
+        }
+        hasTrackedAvatarCreatorRef.current = true
+
         trackTermsOfServiceSuccess({
           ethAddress: account,
           isGuest: false,
@@ -252,7 +263,12 @@ const AvatarSetupPage: React.FC = () => {
       }
       if (event.origin !== previewOrigin) return
 
-      if (event.data.type !== 'controller_response') return
+      // Guard against malformed messages (null data, missing payload). A different preview build
+      // could post a shape we don't expect; that must not throw an uncaught TypeError in the
+      // listener and potentially mask a real customization-done message.
+      const data = event.data
+      if (!data || typeof data !== 'object' || data.type !== 'controller_response') return
+      if (!data.payload || typeof data.payload !== 'object') return
 
       if (event.data.payload.id === 'avatar-customization-step') {
         const step = event.data.payload.result?.step as CustomizationStep
@@ -328,20 +344,28 @@ const AvatarSetupPage: React.FC = () => {
           }
         }
 
-        // Subscribe to the newsletter only if the user has provided an email
-        if (state.email) {
+        // Subscribe to the newsletter respecting consent: for an inherited email, only when the
+        // marketing checkbox is ticked; for a user-typed email, entering it in the newsletter field
+        // is itself the opt-in. Mirrors QuickSetupPage so the two onboarding paths behave the same.
+        let newsletterEmail = ''
+        if (state.isEmailInherited && state.subscribeNewsletter) {
+          newsletterEmail = state.email
+        } else if (!state.isEmailInherited) {
+          newsletterEmail = state.email
+        }
+        if (newsletterEmail) {
           try {
-            await subscribeToNewsletter(state.email)
+            await subscribeToNewsletter(newsletterEmail)
           } catch (e) {
             handleError(e, 'Error subscribing to newsletter', { skipTracking: true })
           }
         }
 
-        const storedEmail = localStorage.getItem('dcl_magic_user_email')
-        if (storedEmail) {
-          // Clear the stored email after using it
-          localStorage.removeItem('dcl_magic_user_email')
-        }
+        // Clear the stored web2 emails after using them. Both keys must go: getStoredEmail reads
+        // the Thirdweb key first, so leaving it behind would let a later in-session account switch
+        // inherit the previous user's email.
+        localStorage.removeItem('dcl_magic_user_email')
+        localStorage.removeItem('dcl_thirdweb_user_email')
         sessionStorage.removeItem('dcl_avatar_setup_username')
         sessionStorage.removeItem('dcl_avatar_setup_email')
         sessionStorage.removeItem('dcl_avatar_setup_is_terms_checked')
@@ -368,6 +392,9 @@ const AvatarSetupPage: React.FC = () => {
           setError(errorMessage)
         }
         setDeploying(false)
+        // Hide the full-screen preview overlay so the error box (and retry) is visible again —
+        // otherwise the fixed, top-of-stack preview covers the error and strands the user.
+        setState(prev => ({ ...prev, showWearablePreview: false }))
       } finally {
         isProcessingMessageRef.current = false
       }
@@ -378,6 +405,8 @@ const AvatarSetupPage: React.FC = () => {
       hasUsernameError,
       state.username,
       state.email,
+      state.isEmailInherited,
+      state.subscribeNewsletter,
       account,
       identity,
       referrer,
@@ -404,6 +433,10 @@ const AvatarSetupPage: React.FC = () => {
     },
     [trackCheckTermsOfService]
   )
+
+  const handleNewsletterChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setState(prev => ({ ...prev, subscribeNewsletter: e.target.checked }))
+  }, [])
 
   const initializeAvatarSetup = useCallback(async () => {
     if (!account || !identity) {
@@ -566,7 +599,13 @@ const AvatarSetupPage: React.FC = () => {
         )}
 
         <CheckboxContainer>
-          {state.isEmailInherited && <CheckboxRow id="marketing" label={t('avatar_setup.email_newsletter')} control={<CheckboxInput />} />}
+          {state.isEmailInherited && (
+            <CheckboxRow
+              id="marketing"
+              label={t('avatar_setup.email_newsletter')}
+              control={<CheckboxInput checked={state.subscribeNewsletter} onChange={handleNewsletterChange} />}
+            />
+          )}
           <CheckboxRow
             id="terms"
             label={

--- a/src/components/Pages/AvatarSetupPage/AvatarSetupPage.types.ts
+++ b/src/components/Pages/AvatarSetupPage/AvatarSetupPage.types.ts
@@ -7,6 +7,10 @@ interface AvatarSetupState {
   showWearablePreview: boolean
   isTermsChecked: boolean
   isEmailInherited: boolean
+  // Consent for the marketing newsletter when the email was inherited from a web2 login. Only
+  // meaningful while isEmailInherited is true; when the user types their own email, entering it in
+  // the newsletter field is itself the opt-in (mirrors QuickSetupPage).
+  subscribeNewsletter: boolean
   hasWearablePreviewLoaded: boolean
 }
 

--- a/src/components/Pages/CallbackPage/CallbackPage.tsx
+++ b/src/components/Pages/CallbackPage/CallbackPage.tsx
@@ -1,14 +1,14 @@
 import { useCallback, useContext, useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
+import { AuthIdentity } from '@dcl/crypto'
 import { ProviderType } from '@dcl/schemas'
-import { localStorageGetIdentity } from '@dcl/single-sign-on-client'
 import { connection } from 'decentraland-connect'
 import { useNavigateWithSearchParams } from '../../../hooks/navigation'
 import { useAnalytics } from '../../../hooks/useAnalytics'
 import { useEnsureProfile } from '../../../hooks/useEnsureProfile'
 import { usePostLoginRedirect } from '../../../hooks/usePostLoginRedirect'
 import { ConnectionType } from '../../../modules/analytics/types'
-import { useCurrentConnectionData } from '../../../shared/connection'
+import { getCachedIdentity, useCurrentConnectionData } from '../../../shared/connection'
 import { isMagicExtensionError, isMagicRpcError } from '../../../shared/errors'
 import { extractReferrerFromSearchParameters, locations } from '../../../shared/locations'
 import { isMobileSession } from '../../../shared/mobile'
@@ -61,11 +61,12 @@ const DesktopCallbackPage = () => {
       throw new Error('No account returned from Magic connection')
     }
 
+    let identity: AuthIdentity | undefined
     if (connectionData.provider) {
-      await getIdentitySignature(connectionData)
+      identity = await getIdentitySignature(connectionData)
     }
 
-    return connectionData
+    return { connectionData, identity }
   }, [flags[FeatureFlagsKeys.MAGIC_TEST], initialized, getIdentitySignature])
 
   const handleContinue = useCallback(
@@ -75,8 +76,8 @@ const DesktopCallbackPage = () => {
       }
 
       try {
-        const connectionData = await connectAndGenerateSignature()
-        if (!connectionData) {
+        const result = await connectAndGenerateSignature()
+        if (!result) {
           // connection.connect() resolved without a connection (returned falsy instead
           // of throwing). Surface a recoverable error so the user gets the Try Again
           // button instead of being stranded on the validating spinner. Mirrors the
@@ -86,6 +87,7 @@ const DesktopCallbackPage = () => {
           return
         }
 
+        const { connectionData, identity: freshIdentity } = result
         const ethAddress = connectionData.account?.toLowerCase() ?? ''
 
         // CP2 reached: social login callback — now we have account + email
@@ -114,8 +116,10 @@ const DesktopCallbackPage = () => {
         // Explorer flow (skipSetup=true): skip this check entirely — the Explorer
         // handles onboarding in-app, so we just redirect back.
         if (!skipSetup && account) {
-          const freshIdentity = localStorageGetIdentity(ethAddress)
-          const profile = await ensureProfile(account, freshIdentity, { redirectTo, referrer, navigateOptions: { replace: true } })
+          // Use the identity just generated; fall back to the validated cache only if the provider
+          // path didn't produce one. Avoids the raw, unvalidated localStorage re-read.
+          const identityForProfile = freshIdentity ?? getCachedIdentity(ethAddress)
+          const profile = await ensureProfile(account, identityForProfile, { redirectTo, referrer, navigateOptions: { replace: true } })
           if (!profile) return
         }
 

--- a/src/components/Pages/LoginPage/AutoLoginRedirect.tsx
+++ b/src/components/Pages/LoginPage/AutoLoginRedirect.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from '@dcl/hooks'
 import { Button, CircularProgress } from 'decentraland-ui2'
@@ -16,6 +16,7 @@ import { handleError } from '../../../shared/utils/errorHandler'
 import { AnimatedBackground } from '../../AnimatedBackground'
 import { ConnectionOptionType, connectionOptionTitles } from '../../Connection/Connection.types'
 import { ConnectionContainer, ConnectionTitle, DecentralandLogo, ProgressContainer } from '../../ConnectionModal/ConnectionLayout.styled'
+import { FeatureFlagsContext, FeatureFlagsKeys } from '../../FeatureFlagsProvider'
 import { Container, Wrapper } from '../../Pages/CallbackPage/CallbackPage.styled'
 import { LoginErrorPage } from '../../Pages/LoginErrorPage'
 import { connectToProvider, connectToSocialProvider, isMagicTestMode, isSocialLogin } from './utils'
@@ -35,15 +36,23 @@ export const AutoLoginRedirect = ({ connectionType }: Props) => {
   const navigate = useNavigate()
 
   const hasStarted = useRef(false)
+  // Set when the user cancels. startLogin checks it after each await so a wallet prompt the user
+  // approves after cancelling can't resurrect the flow (request a signature, redirect, or push the
+  // user into setup) behind their back.
+  const cancelledRef = useRef(false)
   const [phase, setPhase] = useState<Phase>('redirecting')
   // Use a ref for skipSetup so the startLogin callback always reads the latest value.
   // The callback fires once via useEffect, but skipSetup may change after FF loads.
   const skipSetupRef = useRef(skipSetup)
   skipSetupRef.current = skipSetup
 
-  // No feature flag available here (fires before flags load), so pass undefined.
-  // isMagicTestMode falls back to config.is(Env.DEVELOPMENT).
-  const isMagicTest = isMagicTestMode()
+  // Resolve Magic test-mode from the feature flag, exactly as CallbackPage does. Both halves of the
+  // OAuth round-trip MUST agree on the Magic key; if this used only the env fallback while the flag
+  // was set (e.g. dapps-magic-dev-test enabled in prod), the callback would instantiate a different
+  // Magic instance and getRedirectResult would fail. startLogin is gated on `initialized` below so
+  // the flag value is loaded before the redirect starts.
+  const { flags, initialized } = useContext(FeatureFlagsContext)
+  const isMagicTest = isMagicTestMode(flags[FeatureFlagsKeys.MAGIC_TEST])
   const isSocial = isSocialLogin(connectionType)
   const providerName = connectionOptionTitles[connectionType]
 
@@ -52,6 +61,9 @@ export const AutoLoginRedirect = ({ connectionType }: Props) => {
   const rawRedirectTo = useMemo(() => new URLSearchParams(window.location.search).get('redirectTo') ?? undefined, [])
 
   const handleCancel = useCallback(() => {
+    // Mark the flow cancelled so any in-flight startLogin continuation bails out at its next
+    // checkpoint instead of redirecting or prompting after the user has moved on.
+    cancelledRef.current = true
     // Navigate to login page without loginMethod — shows full login UI.
     // Uses navigate() to respect the basename (/auth).
     const params = new URLSearchParams(window.location.search)
@@ -82,6 +94,7 @@ export const AutoLoginRedirect = ({ connectionType }: Props) => {
       }
 
       const connectionData = await connectToProvider(connectionType)
+      if (cancelledRef.current) return
       const ethAddress = connectionData.account?.toLowerCase() ?? ''
 
       // MetaMask connected — now verify and redirect
@@ -99,6 +112,7 @@ export const AutoLoginRedirect = ({ connectionType }: Props) => {
       })
 
       const freshIdentity = await getIdentitySignature(connectionData)
+      if (cancelledRef.current) return
 
       // Clear stale social login emails since this is a wallet login
       localStorage.removeItem('dcl_thirdweb_user_email')
@@ -120,19 +134,31 @@ export const AutoLoginRedirect = ({ connectionType }: Props) => {
       // Skip ensureProfile entirely for Explorer flows (redirectTo points to /auth/requests/).
       // The RequestPage handles profile checking and auto-sign for those flows.
       // For web flows, ensureProfile navigates to QuickSetup if the user has no profile.
-      const isExplorerRedirect = rawRedirectTo?.includes('/auth/requests/') ?? false
+      // Match on the URL pathname (not a substring): a redirectTo like /play?next=/auth/requests/x
+      // must NOT be treated as an Explorer flow, or a new web user would skip setup entirely.
+      let isExplorerRedirect = false
+      if (rawRedirectTo) {
+        try {
+          const redirectUrl = rawRedirectTo.startsWith('/') ? new URL(rawRedirectTo, window.location.origin) : new URL(rawRedirectTo)
+          isExplorerRedirect = redirectUrl.hostname === window.location.hostname && redirectUrl.pathname.startsWith('/auth/requests/')
+        } catch {
+          // Malformed URL — treat as a non-Explorer (web) redirect.
+        }
+      }
       if (!isExplorerRedirect && !skipSetupRef.current && connectionData.account) {
         const profile = await ensureProfile(connectionData.account, freshIdentity, {
           redirectTo,
           referrer: null,
           navigateOptions: { replace: true }
         })
-        if (!profile) return
+        if (cancelledRef.current || !profile) return
       }
 
+      if (cancelledRef.current) return
       markReturningUser(connectionData.account ?? '')
       redirect()
     } catch (error) {
+      if (cancelledRef.current) return
       if (isUserRejectedTransaction(error)) {
         // User cancelled the signature in wallet — navigate to login with walletError param
         // so LoginPage can show the WalletErrorModal. Uses navigate() to respect basename.
@@ -161,10 +187,13 @@ export const AutoLoginRedirect = ({ connectionType }: Props) => {
   ])
 
   useEffect(() => {
-    if (hasStarted.current) return
+    // Wait for feature flags so the Magic key matches the one CallbackPage will use. `initialized`
+    // is fail-open (it flips true even when the flag fetch errors or times out), so this can only
+    // delay auto-login, never block it.
+    if (!initialized || hasStarted.current) return
     hasStarted.current = true
     startLogin()
-  }, [startLogin])
+  }, [initialized, startLogin])
 
   const handleErrorTryAgain = useCallback(() => {
     setPhase('redirecting')

--- a/src/components/Pages/LoginPage/LoginPage.tsx
+++ b/src/components/Pages/LoginPage/LoginPage.tsx
@@ -80,10 +80,12 @@ export const LoginPage = () => {
   const [emailError, setEmailError] = useState<string | null>(null)
   const [showConfirmingLogin, setShowConfirmingLogin] = useState(false)
   const [confirmingLoginError, setConfirmingLoginError] = useState<string | null>(null)
-  // Set when the user closes the connection modal mid-flow. handleOnConnect checks it after each
-  // await so a wallet prompt approved after the modal is dismissed can't redirect or push the user
-  // into setup behind their back.
-  const connectCancelledRef = useRef(false)
+  // Monotonic token identifying the current connect attempt. Each handleOnConnect captures the
+  // value it bumped this ref to and, after every await, bails if the ref has since moved — because
+  // the user closed the modal (which bumps it) or started another attempt. A per-attempt token,
+  // rather than a shared boolean, is required: a boolean set on close would be reset to false by the
+  // next attempt, letting a still-pending earlier attempt resume and redirect behind the user's back.
+  const connectAttemptRef = useRef(0)
   // The last verified email-login result. If a post-verification step (identity, profile) fails,
   // the OTP code is already consumed, so retrying must re-run those steps with this result rather
   // than reopening the OTP modal (where the spent code would fail and the resend cooldown resets).
@@ -237,8 +239,9 @@ export const LoginPage = () => {
       const isLoggingInThroughSocial = isSocialLogin(connectionType)
       const providerType = isLoggingInThroughSocial ? ConnectionType.WEB2 : ConnectionType.WEB3
       setCurrentConnectionType(connectionType)
-      // Fresh attempt — clear any cancellation left over from a previously dismissed modal.
-      connectCancelledRef.current = false
+      // Start a new attempt and capture its token. Any earlier in-flight attempt now has a stale
+      // token and will bail at its next checkpoint instead of resuming.
+      const attemptId = ++connectAttemptRef.current
 
       trackLoginClick({
         method: connectionType,
@@ -262,7 +265,7 @@ export const LoginPage = () => {
           setShowConnectionLayout(true)
           setLoadingState(ConnectionLayoutState.CONNECTING_WALLET)
           const connectionData = await connectToProvider(connectionType)
-          if (connectCancelledRef.current) return
+          if (connectAttemptRef.current !== attemptId) return
 
           // Track CP2 reached after wallet connects so we have the account address
           trackCheckpoint({
@@ -277,7 +280,7 @@ export const LoginPage = () => {
 
           setLoadingState(ConnectionLayoutState.WAITING_FOR_SIGNATURE)
           const freshIdentity = await getIdentitySignature(connectionData)
-          if (connectCancelledRef.current) return
+          if (connectAttemptRef.current !== attemptId) return
 
           // Clear any stored social login emails since this is a wallet login
           localStorage.removeItem('dcl_thirdweb_user_email')
@@ -291,14 +294,14 @@ export const LoginPage = () => {
           const referrer = getReferrerFromCurrentSearch()
 
           const isClockSync = await checkClockSynchronization()
-          if (connectCancelledRef.current) return
+          if (connectAttemptRef.current !== attemptId) return
 
           if (isClockSync) {
             await runProfileRedirect(connectionData.account ?? '', referrer, freshIdentity, () => setShowConnectionLayout(false))
           }
         }
       } catch (error) {
-        if (connectCancelledRef.current) return
+        if (connectAttemptRef.current !== attemptId) return
         if (isUserRejectedTransaction(error)) {
           console.info('User rejected login signature in wallet — not reporting to Sentry')
         } else {
@@ -334,9 +337,10 @@ export const LoginPage = () => {
   )
 
   const handleOnCloseConnectionModal = useCallback(() => {
-    // Abort any in-flight connect so a signature the user approves after dismissing the modal
-    // can't redirect or push them into setup.
-    connectCancelledRef.current = true
+    // Invalidate the in-flight attempt so a signature the user approves after dismissing the modal
+    // can't redirect or push them into setup. Bumping the token (rather than setting a boolean)
+    // ensures a subsequent attempt can't accidentally un-cancel this one.
+    connectAttemptRef.current += 1
     setShowConnectionLayout(false)
     setCurrentConnectionType(undefined)
     setLoadingState(ConnectionLayoutState.CONNECTING_WALLET)

--- a/src/components/Pages/LoginPage/LoginPage.tsx
+++ b/src/components/Pages/LoginPage/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { MouseEvent, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import type { AuthIdentity } from '@dcl/crypto'
 import { useTranslation } from '@dcl/hooks'
 import { connection } from 'decentraland-connect'
@@ -21,7 +21,7 @@ import { useAutoLogin } from '../../../hooks/useAutoLogin'
 import { useEnsureProfile } from '../../../hooks/useEnsureProfile'
 import { usePostLoginRedirect } from '../../../hooks/usePostLoginRedirect'
 import { ConnectionType } from '../../../modules/analytics/types'
-import { useCurrentConnectionData } from '../../../shared/connection'
+import { getCurrentConnectionData, useCurrentConnectionData } from '../../../shared/connection'
 import { isErrorWithName, isUserRejectedTransaction } from '../../../shared/errors'
 import { extractReferrerFromSearchParameters } from '../../../shared/locations'
 import { markReturningUser } from '../../../shared/onboarding/markReturningUser'
@@ -80,6 +80,14 @@ export const LoginPage = () => {
   const [emailError, setEmailError] = useState<string | null>(null)
   const [showConfirmingLogin, setShowConfirmingLogin] = useState(false)
   const [confirmingLoginError, setConfirmingLoginError] = useState<string | null>(null)
+  // Set when the user closes the connection modal mid-flow. handleOnConnect checks it after each
+  // await so a wallet prompt approved after the modal is dismissed can't redirect or push the user
+  // into setup behind their back.
+  const connectCancelledRef = useRef(false)
+  // The last verified email-login result. If a post-verification step (identity, profile) fails,
+  // the OTP code is already consumed, so retrying must re-run those steps with this result rather
+  // than reopening the OTP modal (where the spent code would fail and the resend cooldown resets).
+  const lastEmailLoginResultRef = useRef<EmailLoginResult | null>(null)
 
   // TODO: remove /play from redirectTo. Build guest URL only when redirect path includes /play; use its presence to show the option.
   const guestRedirectToURL = useMemo(() => {
@@ -87,7 +95,9 @@ export const LoginPage = () => {
     try {
       const url = redirectTo.startsWith('/') ? new URL(redirectTo, window.location.origin) : new URL(redirectTo)
       if (!url.pathname.includes('/play')) return ''
-      url.searchParams.append('guest', 'true')
+      // Use set, not append: if redirectTo already carries a guest param, appending would produce
+      // `guest=false&guest=true` and a consumer reading the first value would not enter guest mode.
+      url.searchParams.set('guest', 'true')
       return url.toString()
     } catch {
       return ''
@@ -104,9 +114,24 @@ export const LoginPage = () => {
   const { identity, getIdentitySignature } = useCurrentConnectionData()
   const { trackLoginClick, trackLoginSuccess, trackGuestLogin } = useAnalytics()
 
-  const handleGuestLogin = useCallback(async () => {
-    await trackGuestLogin()
-  }, [trackGuestLogin])
+  const handleGuestLogin = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>) => {
+      // Modified clicks (open in new tab/window) keep this page alive, so the event flushes on its
+      // own — fire it and let the browser handle navigation.
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
+        void trackGuestLogin()
+        return
+      }
+      // Normal click: block the anchor's immediate navigation so the guest-login event has time to
+      // flush to Segment (trackGuestLogin waits TRACKING_DELAY), then navigate ourselves. Navigate
+      // even if tracking rejects so the user is never stranded.
+      event.preventDefault()
+      void trackGuestLogin().finally(() => {
+        window.location.href = guestRedirectToURL
+      })
+    },
+    [trackGuestLogin, guestRedirectToURL]
+  )
 
   const getReferrerFromCurrentSearch = useCallback(() => {
     const search = new URLSearchParams(window.location.search)
@@ -212,6 +237,8 @@ export const LoginPage = () => {
       const isLoggingInThroughSocial = isSocialLogin(connectionType)
       const providerType = isLoggingInThroughSocial ? ConnectionType.WEB2 : ConnectionType.WEB3
       setCurrentConnectionType(connectionType)
+      // Fresh attempt — clear any cancellation left over from a previously dismissed modal.
+      connectCancelledRef.current = false
 
       trackLoginClick({
         method: connectionType,
@@ -235,6 +262,7 @@ export const LoginPage = () => {
           setShowConnectionLayout(true)
           setLoadingState(ConnectionLayoutState.CONNECTING_WALLET)
           const connectionData = await connectToProvider(connectionType)
+          if (connectCancelledRef.current) return
 
           // Track CP2 reached after wallet connects so we have the account address
           trackCheckpoint({
@@ -249,6 +277,7 @@ export const LoginPage = () => {
 
           setLoadingState(ConnectionLayoutState.WAITING_FOR_SIGNATURE)
           const freshIdentity = await getIdentitySignature(connectionData)
+          if (connectCancelledRef.current) return
 
           // Clear any stored social login emails since this is a wallet login
           localStorage.removeItem('dcl_thirdweb_user_email')
@@ -262,12 +291,14 @@ export const LoginPage = () => {
           const referrer = getReferrerFromCurrentSearch()
 
           const isClockSync = await checkClockSynchronization()
+          if (connectCancelledRef.current) return
 
           if (isClockSync) {
             await runProfileRedirect(connectionData.account ?? '', referrer, freshIdentity, () => setShowConnectionLayout(false))
           }
         }
       } catch (error) {
+        if (connectCancelledRef.current) return
         if (isUserRejectedTransaction(error)) {
           console.info('User rejected login signature in wallet — not reporting to Sentry')
         } else {
@@ -303,6 +334,9 @@ export const LoginPage = () => {
   )
 
   const handleOnCloseConnectionModal = useCallback(() => {
+    // Abort any in-flight connect so a signature the user approves after dismissing the modal
+    // can't redirect or push them into setup.
+    connectCancelledRef.current = true
     setShowConnectionLayout(false)
     setCurrentConnectionType(undefined)
     setLoadingState(ConnectionLayoutState.CONNECTING_WALLET)
@@ -341,6 +375,9 @@ export const LoginPage = () => {
 
   const handleEmailLoginSuccess = useCallback(
     async (result: EmailLoginResult) => {
+      // Remember the verified result so a retry after a post-verification failure can resume from
+      // here instead of asking for the (already consumed) OTP code again.
+      lastEmailLoginResultRef.current = result
       setShowEmailLoginModal(false)
       setShowConfirmingLogin(true)
       setConfirmingLoginError(null)
@@ -382,11 +419,17 @@ export const LoginPage = () => {
   }, [])
 
   const handleConfirmingLoginRetry = useCallback(() => {
-    setShowConfirmingLogin(false)
     setConfirmingLoginError(null)
-    // Go back to the email login modal with the current email
-    setShowEmailLoginModal(true)
-  }, [])
+    // The failure happened after the OTP was verified, so the wallet is already connected — re-run
+    // the post-verification steps with the stored result. Only fall back to the OTP modal if we
+    // somehow have no result to resume from.
+    if (lastEmailLoginResultRef.current) {
+      handleEmailLoginSuccess(lastEmailLoginResultRef.current)
+    } else {
+      setShowConfirmingLogin(false)
+      setShowEmailLoginModal(true)
+    }
+  }, [handleEmailLoginSuccess])
 
   // Use the auto-login hook to handle loginMethod URL parameter
   useAutoLogin({
@@ -413,8 +456,14 @@ export const LoginPage = () => {
     }
 
     try {
-      const connectionData = await connectToProvider(currentConnectionType)
-      await runProfileRedirect(connectionData.account ?? '', referrer, null, () => setShowConnectionLayout(false))
+      // Reuse the connection established moments ago instead of reconnecting. connectToProvider
+      // clears WalletConnect storage, which would tear down the active pairing and force a fresh QR
+      // scan (and could bind a different account) just to acknowledge the clock-drift warning.
+      const connectionData = await getCurrentConnectionData()
+      if (!connectionData?.account) {
+        throw new Error('No active connection found for clock sync continue')
+      }
+      await runProfileRedirect(connectionData.account, referrer, connectionData.identity ?? null, () => setShowConnectionLayout(false))
     } catch (error) {
       handleError(error, 'Error during clock sync continue flow')
       // Surface a visible, recoverable error instead of leaving the page silently

--- a/src/components/Pages/MobileAuthPage/MobileAuthPage.tsx
+++ b/src/components/Pages/MobileAuthPage/MobileAuthPage.tsx
@@ -65,6 +65,10 @@ export const MobileAuthPage = () => {
   const [isTestAuthSession, setIsTestAuthSession] = useState(false)
 
   const hasStartedInit = useRef(false)
+  // The last verified email-login result and a stable handle to the post-verification runner, so a
+  // retry after a post-verify failure can resume without re-asking for the (already consumed) OTP.
+  const lastEmailLoginResultRef = useRef<EmailLoginResult | null>(null)
+  const emailLoginSuccessRef = useRef<((result: EmailLoginResult) => void) | null>(null)
 
   const initiateAuth = useCallback(
     async (selectedConnectionType: ConnectionOptionType, options: { fromClick?: boolean } = { fromClick: true }) => {
@@ -189,10 +193,16 @@ export const MobileAuthPage = () => {
     }
 
     // Email has its own OTP flow and can't be re-run via initiateAuth (it would fall
-    // into the wallet branch and call connectToProvider(EMAIL), looping). Route back to
-    // the email UI instead: return to the selection view and reopen the email modal so
-    // the user can retry with the email they already entered.
+    // into the wallet branch and call connectToProvider(EMAIL), looping).
     if (isEmailLogin(connectionType)) {
+      // If OTP was already verified, the failure was in a post-verification step (identity,
+      // postIdentity) and the code is spent — resume those steps with the stored result instead
+      // of reopening the modal to re-enter a code that would fail.
+      if (lastEmailLoginResultRef.current && emailLoginSuccessRef.current) {
+        emailLoginSuccessRef.current(lastEmailLoginResultRef.current)
+        return
+      }
+      // OTP was never verified — reopen the modal so the user can retry with the same email.
       setView('selection')
       setEmailError(null)
       setShowEmailLoginModal(true)
@@ -268,6 +278,8 @@ export const MobileAuthPage = () => {
 
   const handleEmailLoginSuccess = useCallback(
     async (result: EmailLoginResult) => {
+      // Remember the verified result so a retry can resume post-verification without a new code.
+      lastEmailLoginResultRef.current = result
       setShowEmailLoginModal(false)
       setView('connecting')
       setLoadingState(ConnectionLayoutState.WAITING_FOR_SIGNATURE)
@@ -316,6 +328,10 @@ export const MobileAuthPage = () => {
     },
     [trackLoginSuccess]
   )
+
+  // Expose the latest post-verification runner to handleTryAgain (declared earlier) without adding
+  // it to that callback's deps — the ref keeps it stable while always pointing at the current one.
+  emailLoginSuccessRef.current = handleEmailLoginSuccess
 
   // Provider selection view
   if (view === 'selection') {

--- a/src/components/Pages/MobileCallbackPage/MobileCallbackPage.tsx
+++ b/src/components/Pages/MobileCallbackPage/MobileCallbackPage.tsx
@@ -10,7 +10,6 @@ import { ConnectionType } from '../../../modules/analytics/types'
 import { createAuthServerHttpClient } from '../../../shared/auth'
 import { ONE_MONTH_IN_MINUTES, getIdentitySignature } from '../../../shared/connection/identity'
 import { isMagicRpcError } from '../../../shared/errors'
-import { locations } from '../../../shared/locations'
 import { getConnectionOptionFromState } from '../../../shared/oauthState'
 import { handleError } from '../../../shared/utils/errorHandler'
 import { OAUTH_ACCESS_DENIED_ERROR, createMagicInstance } from '../../../shared/utils/magicSdk'
@@ -33,12 +32,26 @@ export const MobileCallbackPage = () => {
   const [identityId, setIdentityId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
+  // Build the /mobile return path preserving the mobile session ids (`u`/`s`). connectToSocialProvider
+  // reads them from the URL to correlate the partner app's analytics/Sentry; a bare locations.mobile()
+  // would drop them and break correlation on the retried login.
+  const buildMobileReturnPath = useCallback(() => {
+    const current = new URLSearchParams(window.location.search)
+    const preserved = new URLSearchParams()
+    const userId = current.get('u')
+    const sessionId = current.get('s')
+    if (userId) preserved.set('u', userId)
+    if (sessionId) preserved.set('s', sessionId)
+    const query = preserved.toString()
+    return `/mobile${query ? `?${query}` : ''}`
+  }, [])
+
   const processOAuthCallback = useCallback(async () => {
     // Check for OAuth error in URL params before getRedirectResult() strips them
     const oauthError = new URLSearchParams(window.location.search).get('error')
     if (oauthError === OAUTH_ACCESS_DENIED_ERROR) {
       // User cancelled at the OAuth provider — not an error, go back to mobile login
-      navigate(locations.mobile())
+      navigate(buildMobileReturnPath())
       return
     }
 
@@ -84,7 +97,7 @@ export const MobileCallbackPage = () => {
       })
       setError(err instanceof Error ? err.message : 'Authentication failed')
     }
-  }, [isMagicTest, navigate, trackLoginSuccess])
+  }, [isMagicTest, navigate, trackLoginSuccess, buildMobileReturnPath])
 
   useEffect(() => {
     if (!initialized || hasStartedProcessing.current) return
@@ -94,8 +107,8 @@ export const MobileCallbackPage = () => {
   }, [initialized, processOAuthCallback])
 
   const handleRetry = useCallback(() => {
-    navigate(locations.mobile())
-  }, [navigate])
+    navigate(buildMobileReturnPath())
+  }, [navigate, buildMobileReturnPath])
 
   // Show error state
   if (error) {

--- a/src/components/Pages/RequestPage/RequestPage.spec.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.spec.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ProviderType } from '@dcl/schemas'
+import { TrackingEvents } from '../../../modules/analytics/types'
 import { fetchProfile } from '../../../modules/profile'
 import {
   DifferentSenderError,
@@ -15,7 +16,6 @@ import {
 import { getAuthRequestId, isBridgeOnlyEnabled } from '../../../shared/locations'
 import { isProfileComplete } from '../../../shared/profile'
 import { trackEvent } from '../../../shared/utils/analytics'
-import { TrackingEvents } from '../../../modules/analytics/types'
 import { FeatureFlagsContext } from '../../FeatureFlagsProvider'
 import { RequestPage } from './RequestPage'
 import { decodeManaTransferData, decodeNftTransferData, fetchNftMetadata, getSigninDeeplink } from './utils'

--- a/src/components/Pages/RequestPage/RequestPage.spec.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.spec.tsx
@@ -60,6 +60,12 @@ jest.mock('../../../modules/analytics/segment', () => ({
   getAnalytics: () => null
 }))
 
+// Make the outcome-delivery retry backoff instant so the retry-path tests don't wait on real timers.
+jest.mock('../../../shared/time', () => ({
+  ...jest.requireActual('../../../shared/time'),
+  wait: () => Promise.resolve()
+}))
+
 // --- Auth Server Client ---
 const mockRecover = jest.fn()
 const mockSendSuccessfulOutcome = jest.fn()
@@ -877,6 +883,32 @@ describe('RequestPage', () => {
       await userEvent.click(await screen.findByTestId('wallet-interaction-approve'))
       expect(await screen.findByTestId('wallet-interaction-complete')).toBeInTheDocument()
     })
+
+    describe('and the outcome delivery fails after signing', () => {
+      beforeEach(() => {
+        mockSendSuccessfulOutcome.mockRejectedValue(new Error('network error'))
+      })
+
+      it('should retry delivering the signature before giving up', async () => {
+        renderRequestPage()
+        await userEvent.click(await screen.findByTestId('wallet-interaction-approve'))
+        await waitFor(() => expect(mockSendSuccessfulOutcome).toHaveBeenCalledTimes(3))
+      })
+
+      it('should show the signing error instead of a false completion, since the signature was never delivered', async () => {
+        renderRequestPage()
+        await userEvent.click(await screen.findByTestId('wallet-interaction-approve'))
+        expect(await screen.findByTestId('signing-error')).toBeInTheDocument()
+        expect(screen.queryByTestId('wallet-interaction-complete')).not.toBeInTheDocument()
+      })
+
+      it('should not send a failed outcome, since the signature itself succeeded', async () => {
+        renderRequestPage()
+        await userEvent.click(await screen.findByTestId('wallet-interaction-approve'))
+        await screen.findByTestId('signing-error')
+        expect(mockSendFailedOutcome).not.toHaveBeenCalled()
+      })
+    })
   })
 
   describe('when a Thirdweb user approves a transaction', () => {
@@ -1123,6 +1155,26 @@ describe('RequestPage', () => {
       await screen.findByTestId('wallet-interaction-complete')
 
       expect(mockCheckMetaTransactionSupport.mock.calls.length).toBe(callsAfterPrefetch)
+    })
+
+    describe('and the outcome delivery fails after the transaction is broadcast', () => {
+      beforeEach(() => {
+        mockWalletRequest.mockResolvedValue('0xhash')
+        mockSendSuccessfulOutcome.mockRejectedValue(new Error('network error'))
+      })
+
+      it('should show completion, since the transaction is already on-chain', async () => {
+        renderRequestPage()
+        await userEvent.click(await screen.findByTestId('wallet-interaction-approve'))
+        expect(await screen.findByTestId('wallet-interaction-complete')).toBeInTheDocument()
+      })
+
+      it('should not send a failed outcome, which would prompt the user to resubmit an executed transaction', async () => {
+        renderRequestPage()
+        await userEvent.click(await screen.findByTestId('wallet-interaction-approve'))
+        await screen.findByTestId('wallet-interaction-complete')
+        expect(mockSendFailedOutcome).not.toHaveBeenCalled()
+      })
     })
 
     describe('and the simulation request fails', () => {

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -150,7 +150,6 @@ export const RequestPage = () => {
   const [skipDeepLinkRedirect, setSkipDeepLinkRedirect] = useState(false)
   const [walletInfo, setWalletInfo] = useState<{
     balance: bigint
-    chainId: number
   }>()
   const [transactionGasCost, setTransactionGasCost] = useState<bigint>()
   const [nftTransferData, setNftTransferData] = useState<NFTTransferData | null>(null)
@@ -563,8 +562,7 @@ export const RequestPage = () => {
               if (cancelled) return
 
               setWalletInfo({
-                balance: userBalance,
-                chainId: currentChainId
+                balance: userBalance
               })
 
               // Check if this is an NFT transfer or MANA transfer by analyzing the transaction data
@@ -1008,6 +1006,11 @@ export const RequestPage = () => {
     setIsLoading(true)
     setIsTransactionModalOpen(false)
     const walletClient = walletClientRef.current
+    // Holds the wallet result (tx hash or signature) once the action actually executes. Declared
+    // outside the try so the catch can distinguish a broadcast/signed action whose outcome merely
+    // failed to deliver from an action that never happened — the former must never be reported as a
+    // failed outcome (that would tell the Explorer a confirmed tx was rejected, inviting a double-submit).
+    let result: string | null = null
     try {
       if (!walletClient) {
         throw new Error('Provider not created')
@@ -1019,8 +1022,6 @@ export const RequestPage = () => {
 
       const [signerAddress] = await walletClient.getAddresses()
       const method = requestRef.current.method
-
-      let result: string | null = null
 
       if (method !== 'eth_sendTransaction') {
         // Non-transaction methods (e.g. personal_sign, eth_signTypedData_v4) carry no `to`
@@ -1091,7 +1092,23 @@ export const RequestPage = () => {
         setView(View.WALLET_INTERACTION_COMPLETE)
       }
     } catch (e) {
-      if (isUserRejectedTransaction(e)) {
+      if (result) {
+        // The wallet already broadcast the transaction (or produced the signature) — `result` holds
+        // it. Any error past this point is a post-execution problem (outcome delivery, tip
+        // notification), NOT a transaction failure, so report success: sending a failed outcome here
+        // would tell the Explorer a confirmed tx was rejected and prompt the user to resubmit.
+        handleError(e, 'Wallet interaction succeeded but post-execution step failed', {
+          sentryTags: { isWeb2Wallet: isUserUsingWeb2Wallet }
+        })
+        hasCompletedRef.current = true
+        if (nftTransferData) {
+          setView(View.WALLET_NFT_INTERACTION_COMPLETE)
+        } else if (manaTransferData) {
+          setView(View.WALLET_MANA_INTERACTION_COMPLETE)
+        } else {
+          setView(View.WALLET_INTERACTION_COMPLETE)
+        }
+      } else if (isUserRejectedTransaction(e)) {
         console.info('User rejected wallet interaction in wallet — not reporting to Sentry')
         try {
           if (walletClientRef.current) {
@@ -1178,15 +1195,11 @@ export const RequestPage = () => {
       trackClick(ClickEvents.IDENTITY_DEEP_LINK_OPENED, { authRequestId: requestId })
     }
 
-    // Deep-link flow: the client was opened via the deep link and there is nothing to
-    // navigate to — stay on the ContinueInApp view, which doubles as the retry fallback.
-    if (isDeepLinkFlow) return
-
-    // The deep link already fired in ContinueInApp — skip the auto-redirect in SignInCompletePage
-    setSkipDeepLinkRedirect(true)
-    // Show completion view
-    setView(View.VERIFY_SIGN_IN_COMPLETE)
-  }, [identityId, trackClick, isDeepLinkFlow, requestId])
+    // The ContinueInApp view is only ever reached in the deep-link flow — completeClientLoginFlow
+    // is the sole setter of DEEP_LINK_CONTINUE_IN_APP and it runs only when isDeepLinkFlow is true.
+    // The client was opened via the deep link and there is nothing to navigate to, so stay on this
+    // view, which doubles as the retry fallback.
+  }, [identityId, trackClick, requestId])
 
   const onRetryClientLogin = useCallback(() => {
     // A fresh mount re-runs completeClientLoginFlow: the view resets to LOADING_REQUEST and

--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -39,6 +39,7 @@ import {
 } from '../../../shared/locations'
 import { sendTipNotification } from '../../../shared/notifications'
 import { isProfileComplete } from '../../../shared/profile'
+import { wait } from '../../../shared/time'
 import { identifyUser, trackEvent } from '../../../shared/utils/analytics'
 import { handleError } from '../../../shared/utils/errorHandler'
 import { FeatureFlagsContext, FeatureFlagsKeys } from '../../FeatureFlagsProvider/FeatureFlagsProvider.types'
@@ -133,6 +134,12 @@ const TERMINAL_VIEWS = new Set([
   View.DIFFERENT_ACCOUNT,
   View.IP_VALIDATION_ERROR
 ])
+
+// The successful-outcome POST is the only channel by which the requester receives an off-chain
+// signature (a broadcast tx is recoverable on-chain, a signature is not), so it is delivered with a
+// few retries before giving up, to ride out a transient failure rather than dropping the result.
+const OUTCOME_DELIVERY_ATTEMPTS = 3
+const OUTCOME_DELIVERY_RETRY_MS = 1000
 
 export const RequestPage = () => {
   const params = useParams()
@@ -1078,7 +1085,21 @@ export const RequestPage = () => {
       trackClick(ClickEvents.APPROVE_WALLET_INTERACTION, {
         method: requestRef.current?.method
       })
-      await authServerClient.current.sendSuccessfulOutcome(requestId, signerAddress, result)
+
+      // The action already executed and `result` holds its tx hash / signature. Deliver the outcome,
+      // resending the captured result on a transient failure — for an off-chain signature this POST
+      // is the only way the requester ever receives it. A RequestFulfilledError means the outcome is
+      // already recorded (e.g. another tab delivered it), so treat that as delivered.
+      for (let attempt = 1; ; attempt++) {
+        try {
+          await authServerClient.current.sendSuccessfulOutcome(requestId, signerAddress, result)
+          break
+        } catch (deliveryError) {
+          if (deliveryError instanceof RequestFulfilledError) break
+          if (attempt >= OUTCOME_DELIVERY_ATTEMPTS) throw deliveryError
+          await wait(OUTCOME_DELIVERY_RETRY_MS)
+        }
+      }
       hasCompletedRef.current = true
 
       if (nftTransferData) {
@@ -1092,12 +1113,13 @@ export const RequestPage = () => {
         setView(View.WALLET_INTERACTION_COMPLETE)
       }
     } catch (e) {
-      if (result) {
-        // The wallet already broadcast the transaction (or produced the signature) — `result` holds
-        // it. Any error past this point is a post-execution problem (outcome delivery, tip
-        // notification), NOT a transaction failure, so report success: sending a failed outcome here
-        // would tell the Explorer a confirmed tx was rejected and prompt the user to resubmit.
-        handleError(e, 'Wallet interaction succeeded but post-execution step failed', {
+      const isBroadcastTransaction = requestRef.current?.method === 'eth_sendTransaction'
+      if (result && isBroadcastTransaction) {
+        // The transaction was already broadcast and its hash is recoverable on-chain, so a
+        // post-broadcast failure (outcome delivery, tip notification) is NOT a transaction failure.
+        // Report success and never send a failed outcome — that would tell the Explorer a confirmed
+        // tx was rejected and prompt the user to resubmit (double tip / double transfer).
+        handleError(e, 'Transaction broadcast but a post-broadcast step failed', {
           sentryTags: { isWeb2Wallet: isUserUsingWeb2Wallet }
         })
         hasCompletedRef.current = true
@@ -1149,21 +1171,27 @@ export const RequestPage = () => {
           sentryTags: { isWeb2Wallet: isUserUsingWeb2Wallet }
         })
 
-        // Try to send failed outcome, but don't let it prevent showing the error view
-        try {
-          if (walletClientRef.current) {
-            const [addr] = await walletClientRef.current.getAddresses()
-            if (isRpcError(e)) {
-              await authServerClient.current.sendFailedOutcome(requestId, addr, e.error)
-            } else {
-              await authServerClient.current.sendFailedOutcome(requestId, addr, {
-                code: 999,
-                message: isErrorWithMessage(e) ? e.message : 'Unknown error'
-              })
+        // Only report a failed outcome when nothing executed. If `result` is set here, it is an
+        // off-chain signature whose delivery failed after retries: the signature itself SUCCEEDED,
+        // so a failed outcome would wrongly tell the requester it was rejected. Leave no outcome so
+        // the request can be re-initiated and the signature re-delivered.
+        if (!result) {
+          // Try to send failed outcome, but don't let it prevent showing the error view
+          try {
+            if (walletClientRef.current) {
+              const [addr] = await walletClientRef.current.getAddresses()
+              if (isRpcError(e)) {
+                await authServerClient.current.sendFailedOutcome(requestId, addr, e.error)
+              } else {
+                await authServerClient.current.sendFailedOutcome(requestId, addr, {
+                  code: 999,
+                  message: isErrorWithMessage(e) ? e.message : 'Unknown error'
+                })
+              }
             }
+          } catch (failedOutcomeError) {
+            console.error('Failed to send failed outcome:', failedOutcomeError)
           }
-        } catch (failedOutcomeError) {
-          console.error('Failed to send failed outcome:', failedOutcomeError)
         }
 
         setError(isErrorWithMessage(e) ? e.message : 'Unknown error')

--- a/src/components/Pages/RequestPage/utils.ts
+++ b/src/components/Pages/RequestPage/utils.ts
@@ -18,6 +18,12 @@ const HEX_STRING_REGEX = /^0x([0-9a-fA-F]{2})*$/
 // never actually reaches this view-selection logic.
 const SIGNATURE_METHODS = new Set(['personal_sign', 'eth_sign', 'eth_signtypeddata', 'eth_signtypeddata_v3', 'eth_signtypeddata_v4'])
 
+// ERC721 transfer methods that move a single token and share the (from, to, uint256 tokenId)
+// argument shape the branded gift view relies on. Batch variants (batchTransferFrom /
+// safeBatchTransferFrom) put a uint256[] in the third arg, so they are deliberately excluded —
+// decoding them as a single tokenId yields a bogus value and later throws in BigInt().
+const SINGLE_TOKEN_TRANSFER_METHODS = new Set(['transferFrom', 'safeTransferFrom'])
+
 /**
  * Returns true when the method is a plain signature request (not a transaction and not the
  * dedicated dcl_personal_sign sign-in flow).
@@ -397,24 +403,27 @@ function decodeNftTransferData(data: string, contractABI: object[]): { tokenId: 
     if (!data || data.length < 10) return null
 
     // Decode the transaction data using the ABI
-    const { args } = decodeFunctionData({
+    const { functionName, args } = decodeFunctionData({
       abi: contractABI as readonly unknown[],
       data: data as `0x${string}`
     })
 
-    if (!args || args.length < 3) {
-      console.error('Failed to decode transaction data')
+    // Only single-token transfers carry the (from, to, uint256 tokenId) shape this view expects.
+    // Anything else (batch transfers, unrelated methods) falls through to the generic simulation
+    // + acknowledgment path instead of being mis-decoded into a bogus tokenId.
+    if (!SINGLE_TOKEN_TRANSFER_METHODS.has(functionName) || !args || args.length < 3) {
       return null
     }
 
-    // All ERC721 transfer methods have these parameters:
     // transferFrom(address from, address to, uint256 tokenId)
-    // safeTransferFrom(address from, address to, uint256 tokenId)
-    // safeTransferFrom(address from, address to, uint256 tokenId, bytes data)
+    // safeTransferFrom(address from, address to, uint256 tokenId[, bytes data])
     const toAddress = args[1] as string // 'to' address is always the second parameter
-    const tokenId = (args[2] as bigint).toString() // tokenId is always the third parameter
+    const tokenId = args[2] // tokenId is always the third parameter
+    if (typeof tokenId !== 'bigint') {
+      return null
+    }
 
-    return { tokenId, toAddress }
+    return { tokenId: tokenId.toString(), toAddress }
   } catch (error) {
     console.error('Error decoding NFT transfer data:', error)
     return null

--- a/src/components/Pages/SetupPage/SetupPage.tsx
+++ b/src/components/Pages/SetupPage/SetupPage.tsx
@@ -368,7 +368,9 @@ export const SetupPage = () => {
 
     if (!account || !identity) {
       console.warn('No previous connection found')
-      navigate(locations.login(redirectTo))
+      // Carry the referrer through to login so referral attribution survives the bounce, matching
+      // AvatarSetupPage and QuickSetupPage.
+      navigate(locations.login(redirectTo, referrer))
       return
     }
 

--- a/src/components/Pages/SetupPage/utils.spec.ts
+++ b/src/components/Pages/SetupPage/utils.spec.ts
@@ -74,7 +74,8 @@ describe('when subscribing to the newsletter', () => {
           method: 'post',
           body: JSON.stringify({ email: mockEmail, source: 'auth' }),
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          headers: { 'content-type': 'application/json' }
+          headers: { 'content-type': 'application/json' },
+          signal: expect.any(AbortSignal)
         })
       })
     })

--- a/src/components/Pages/SetupPage/utils.ts
+++ b/src/components/Pages/SetupPage/utils.ts
@@ -3,7 +3,12 @@ import { AuthIdentity, Authenticator } from '@dcl/crypto'
 import { EntityType } from '@dcl/schemas'
 import { config } from '../../../modules/config'
 import { deployWithCatalystRotation } from '../../../modules/profile'
-import { fetcher } from '../../../shared/fetcher'
+import { createFetcher } from '../../../shared/fetcher'
+
+// These calls run in the onboarding submit path, mostly after the profile has already deployed, so
+// they must be bounded: a hung server would otherwise leave the user stuck on the deploying spinner
+// indefinitely rather than surfacing (or swallowing) a failure.
+const REQUEST_TIMEOUT_MS = 10_000
 
 async function subscribeToNewsletter(email: string) {
   const url = config.get('BUILDER_SERVER_URL')
@@ -16,7 +21,8 @@ async function subscribeToNewsletter(email: string) {
     method: 'post',
     body: JSON.stringify({ email, source: 'auth' }),
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    headers: { 'content-type': 'application/json' }
+    headers: { 'content-type': 'application/json' },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
   })
 
   if (!response.ok) {
@@ -37,21 +43,28 @@ async function deployProfileFromDefault({
   connectedAccountIdentity: AuthIdentity
   disabledCatalysts?: string[]
 }) {
-  // Create the content client to fetch and deploy profiles.
+  // Create the content client to fetch and deploy profiles. Use a timeout-bounded fetcher so a
+  // stalled PEER catalyst can't hang the entity fetch forever (the deploy step below already
+  // rotates across catalysts with its own timeout).
   const peerUrl = config.get('PEER_URL', '')
-  const client = createContentClient({ url: peerUrl + '/content', fetcher })
+  const client = createContentClient({ url: peerUrl + '/content', fetcher: createFetcher({ timeout: REQUEST_TIMEOUT_MS }) })
 
   // Fetch the entity of the currently selected default profile.
   const defaultEntities = await client.fetchEntitiesByPointers([defaultProfile])
   const defaultEntity = defaultEntities[0]
+
+  // The default-profile pointer can come back empty (unsynced/pruned on the catalyst). Fail with a
+  // clear message instead of a cryptic "cannot read properties of undefined" further down.
+  const avatar = defaultEntity?.metadata?.avatars?.[0]
+  if (!avatar) {
+    throw new Error(`Default profile "${defaultProfile}" could not be loaded. Try selecting another default look.`)
+  }
 
   // Both org and zone content server profiles have legacy ids for wearables and body shapes.
   // We need to map them to urns to be able to deploy the profile.
   const mapLegacyIdToUrn = (urn: string) => urn.replace('dcl://base-avatars/', 'urn:decentraland:off-chain:base-avatars:')
 
   // Override the default avatar with the provided name and connected account address.
-  const avatar = defaultEntity.metadata.avatars?.[0]
-
   avatar.name = deploymentProfileName
   avatar.ethAddress = connectedAccount
   avatar.userId = connectedAccount

--- a/src/hooks/useTrackReferral.ts
+++ b/src/hooks/useTrackReferral.ts
@@ -5,6 +5,9 @@ import { useCurrentConnectionData } from '../shared/connection'
 import { handleErrorWithContext } from '../shared/utils/errorHandler'
 
 const REFERRAL_SERVER_URL = config.get('REFERRAL_SERVER_URL')
+// Referral tracking is awaited in the onboarding submit path, so bound it: a hung referral server
+// must not strand the user on the deploying spinner after their profile has already deployed.
+const REFERRAL_TIMEOUT_MS = 10_000
 
 export const useTrackReferral = () => {
   const { identity, account } = useCurrentConnectionData()
@@ -25,7 +28,8 @@ export const useTrackReferral = () => {
             'Content-Type': 'application/json'
           },
           ...(body && { body }),
-          identity
+          identity,
+          signal: AbortSignal.timeout(REFERRAL_TIMEOUT_MS)
         })
       } catch (error) {
         handleErrorWithContext(error, 'Failed to track referral progress', {

--- a/src/modules/profile/deploy.ts
+++ b/src/modules/profile/deploy.ts
@@ -70,8 +70,11 @@ async function deployWithCatalystRotation({ entity, disabledCatalysts }: DeployW
 
 function isRetryableError(error: unknown): boolean {
   if (error instanceof DeploymentError && error.statusCode !== undefined) {
-    // Don't retry on 4xx client errors (bad request, auth issues, etc.)
-    return error.statusCode >= 500
+    // Retry on server errors (5xx) and on transient per-server conditions another catalyst is
+    // likely to accept: 429 (rate limited) and 408 (request timeout). Other 4xx (e.g. 400 bad
+    // request, auth) are deterministic — the same payload would fail on every catalyst, so don't
+    // waste the remaining attempts.
+    return error.statusCode >= 500 || error.statusCode === 429 || error.statusCode === 408
   }
 
   // Network errors (no response at all) are retryable

--- a/src/modules/profile/index.ts
+++ b/src/modules/profile/index.ts
@@ -189,7 +189,10 @@ async function redeployExistingProfileWithContentServerData(
   connectedAccountIdentity: AuthIdentity,
   disabledCatalysts: string[] = []
 ): Promise<void> {
-  const client = createContentClient({ url: catalystUrl + '/content', fetcher: createFetcher() })
+  // Bound the entity fetch with a timeout (matching the consistency-check path) so a stalled
+  // catalyst can't hang the login/callback flow that awaits this fallback redeploy on the spinner.
+  const fetcher = createFetcher({ timeout: Number(config.get('PROFILE_CONSISTENCY_CHECK_TIMEOUT')) || 10000 })
+  const client = createContentClient({ url: catalystUrl + '/content', fetcher })
   const entity = (await client.fetchEntitiesByPointers([connectedAccount]))?.[0]
   if (!entity) {
     throw new Error('Profile entity not found')

--- a/src/shared/auth/httpClient.spec.ts
+++ b/src/shared/auth/httpClient.spec.ts
@@ -1,6 +1,7 @@
 import { AuthIdentity } from '@dcl/crypto'
 import signedFetchMock from 'decentraland-crypto-fetch'
 import { getAnalytics } from '../../modules/analytics/segment'
+import { TrackingEvents } from '../../modules/analytics/types'
 import { config } from '../../modules/config'
 import {
   DifferentSenderError,
@@ -9,7 +10,6 @@ import {
   RequestNotFoundError,
   SimulationUnavailableError
 } from './errors'
-import { TrackingEvents } from '../../modules/analytics/types'
 import { createAuthServerHttpClient } from './httpClient'
 import { RecoverResponse, SimulationRequestBody, SimulationResponseBody } from './types'
 // Mock dependencies
@@ -198,7 +198,8 @@ describe('createAuthServerClient', () => {
           body: JSON.stringify({
             sender: mockSender,
             result: mockResult
-          })
+          }),
+          signal: expect.any(AbortSignal)
         })
       })
     })
@@ -285,7 +286,8 @@ describe('createAuthServerClient', () => {
           body: JSON.stringify({
             sender: mockSender,
             error: mockError
-          })
+          }),
+          signal: expect.any(AbortSignal)
         })
       })
     })
@@ -439,10 +441,10 @@ describe('createAuthServerClient', () => {
         expect(result).toEqual(mockResponse)
       })
 
-      it('should track the success without an authRequestId when none is provided', async () => {
+      it('should not track a deep-link auth success when no authRequestId is provided', async () => {
         await client.postIdentity(mockIdentity)
 
-        expect(mockTrack).toHaveBeenCalledWith(TrackingEvents.DEEP_LINK_AUTH_SUCCESS, { type: 'success' })
+        expect(mockTrack).not.toHaveBeenCalledWith(TrackingEvents.DEEP_LINK_AUTH_SUCCESS, expect.anything())
       })
 
       it('should forward the authRequestId onto the success tracking event when provided', async () => {

--- a/src/shared/auth/httpClient.ts
+++ b/src/shared/auth/httpClient.ts
@@ -17,6 +17,10 @@ import { assertMethodIsAllowed, assertRequestIsNotImpersonatingSignIn } from './
 import { IdentityResponse, OutcomeError, OutcomeResponse, RecoverResponse, SimulationRequestBody, SimulationResponseBody } from './types'
 
 const SIMULATION_TIMEOUT_MS = 10_000
+// Outcome delivery is a write that follows an already-executed action, so it gets a more generous
+// budget than the read-only simulation — but it must still be bounded so a hung auth server can't
+// leave the interaction spinner up indefinitely.
+const OUTCOME_TIMEOUT_MS = 15_000
 export const createAuthServerHttpClient = (authServerUrl?: string) => {
   const baseUrl = authServerUrl ?? config.get('AUTH_SERVER_URL')
 
@@ -54,7 +58,8 @@ export const createAuthServerHttpClient = (authServerUrl?: string) => {
         body: JSON.stringify({
           sender,
           result
-        })
+        }),
+        signal: AbortSignal.timeout(OUTCOME_TIMEOUT_MS)
       })
 
       if (!response.ok) {
@@ -97,10 +102,15 @@ export const createAuthServerHttpClient = (authServerUrl?: string) => {
 
       const data = await response.json()
 
-      trackEvent(TrackingEvents.DEEP_LINK_AUTH_SUCCESS, {
-        type: 'success',
-        ...(opts.authRequestId ? { authRequestId: opts.authRequestId } : {})
-      })
+      // Only the deep-link handoff carries an authRequestId; the standalone mobile login callers
+      // pass none. Emit the deep-link success event solely for the former so the two flows aren't
+      // conflated in analytics ("Deep link auth success" with no request id is not a deep link).
+      if (opts.authRequestId) {
+        trackEvent(TrackingEvents.DEEP_LINK_AUTH_SUCCESS, {
+          type: 'success',
+          authRequestId: opts.authRequestId
+        })
+      }
 
       return data
     } catch (e) {
@@ -120,7 +130,8 @@ export const createAuthServerHttpClient = (authServerUrl?: string) => {
         body: JSON.stringify({
           sender,
           error
-        })
+        }),
+        signal: AbortSignal.timeout(OUTCOME_TIMEOUT_MS)
       })
 
       if (!response.ok) {

--- a/src/shared/auth/signMethodGuard.spec.ts
+++ b/src/shared/auth/signMethodGuard.spec.ts
@@ -1,3 +1,4 @@
+import { stringToHex } from 'viem'
 import { ImpersonatedSignInError, UnsupportedMethodError } from './errors'
 import { assertMethodIsAllowed, assertRequestIsNotImpersonatingSignIn, isDecentralandIdentityAuthMessage } from './signMethodGuard'
 
@@ -52,6 +53,36 @@ describe('isDecentralandIdentityAuthMessage', () => {
 
     beforeEach(() => {
       message = 'Sign this message to prove you own this wallet'
+    })
+
+    it('should return false', () => {
+      expect(isDecentralandIdentityAuthMessage(message)).toBe(false)
+    })
+  })
+
+  describe('when the message is a hex-encoded sign-in payload as personal_sign delivers it', () => {
+    let message: string
+
+    beforeEach(() => {
+      message = stringToHex(
+        [
+          'Decentraland Login',
+          'Ephemeral address: 0x1234567890123456789012345678901234567890',
+          'Expiration: 2100-01-01T00:00:00.000Z'
+        ].join('\n')
+      )
+    })
+
+    it('should return true after decoding the hex, so the plaintext check cannot be bypassed', () => {
+      expect(isDecentralandIdentityAuthMessage(message)).toBe(true)
+    })
+  })
+
+  describe('when the message is a hex-encoded regular text', () => {
+    let message: string
+
+    beforeEach(() => {
+      message = stringToHex('Sign this message to prove you own this wallet')
     })
 
     it('should return false', () => {
@@ -140,6 +171,18 @@ describe('assertRequestIsNotImpersonatingSignIn', () => {
 
     it('should throw an ImpersonatedSignInError regardless of the param order', () => {
       expect(() => assertRequestIsNotImpersonatingSignIn('eth_sign', params)).toThrow(ImpersonatedSignInError)
+    })
+  })
+
+  describe('when the method is personal_sign and the message is a hex-encoded sign-in payload', () => {
+    let params: unknown[]
+
+    beforeEach(() => {
+      params = [stringToHex(signInPayload)]
+    })
+
+    it('should throw an ImpersonatedSignInError because the hex is decoded before the check', () => {
+      expect(() => assertRequestIsNotImpersonatingSignIn('personal_sign', params)).toThrow(ImpersonatedSignInError)
     })
   })
 

--- a/src/shared/auth/signMethodGuard.ts
+++ b/src/shared/auth/signMethodGuard.ts
@@ -1,3 +1,4 @@
+import { hexToString } from 'viem'
 import { ImpersonatedSignInError, UnsupportedMethodError } from './errors'
 
 // The Decentraland-specific signing method used by the sign-in flow. It is the only
@@ -48,6 +49,10 @@ function assertMethodIsAllowed(method: string): void {
 const EPHEMERAL_ADDRESS_LINE_PREFIX = 'Ephemeral address: 0x'
 const EXPIRATION_LINE_PREFIX = 'Expiration: '
 
+// A hex-encoded byte string, the form personal_sign messages take on the wire (e.g. MetaMask
+// encodes the UTF-8 message as hex). Only even-length all-hex `0x…` values qualify.
+const HEX_STRING_REGEX = /^0x([0-9a-fA-F]{2})*$/
+
 /**
  * Returns whether a message replicates the Decentraland identity-authorization payload
  * that the `dcl_personal_sign` sign-in flow asks the user to sign. Detection mirrors how
@@ -59,7 +64,20 @@ function isDecentralandIdentityAuthMessage(message: unknown): boolean {
     return false
   }
 
-  const lines = message.replace(/\r/g, '').split('\n')
+  // personal_sign carries its message hex-encoded and the wallet decodes it to UTF-8 before
+  // signing, so a hex-wrapped sign-in payload would still yield a usable auth chain. Decode it
+  // here too (mirroring extractSignaturePayload) so the structural check below can't be bypassed
+  // by hex-encoding. A non-hex message is checked as-is; invalid hex falls back to the raw value.
+  let decoded = message
+  if (HEX_STRING_REGEX.test(message) && message.length > 2) {
+    try {
+      decoded = hexToString(message as `0x${string}`)
+    } catch {
+      decoded = message
+    }
+  }
+
+  const lines = decoded.replace(/\r/g, '').split('\n')
   if (lines.length < 3) {
     return false
   }

--- a/src/shared/connection/ConnectionProvider.tsx
+++ b/src/shared/connection/ConnectionProvider.tsx
@@ -50,6 +50,12 @@ const ConnectionProvider = ({ children }: PropsWithChildren) => {
   // concurrent callers for the SAME account share a single wallet signature prompt,
   // while callers for DIFFERENT accounts never receive the wrong account's identity.
   const inflightIdentityRef = useRef<Map<string, Promise<AuthIdentity>>>(new Map())
+  // Bumped on every wallet accountsChanged/disconnect, alongside the account it reported. An
+  // in-flight getIdentitySignature captures the version at start and, on completion, publishes its
+  // result unless the active account has since switched to a DIFFERENT one — which would mean this
+  // result is for the account the user left, and publishing it would clobber the newer account.
+  const accountVersionRef = useRef(0)
+  const lastEventAccountRef = useRef<string | undefined>(undefined)
 
   /**
    * Fetches the current connection data (account, identity, provider, etc.)
@@ -82,6 +88,7 @@ const ConnectionProvider = ({ children }: PropsWithChildren) => {
     }
 
     const promise = (async () => {
+      const versionAtStart = accountVersionRef.current
       const connectionResponse = existingConnection ?? (await connection.tryPreviousConnection())
 
       // Validate that all required fields are present, including providerType,
@@ -92,14 +99,22 @@ const ConnectionProvider = ({ children }: PropsWithChildren) => {
 
       const identity = await getIdentitySignatureUtil(connectionResponse.account, connectionResponse.provider)
 
-      setState({
-        isLoading: false,
-        account: connectionResponse.account,
-        identity,
-        provider: connectionResponse.provider,
-        providerType: connectionResponse.providerType,
-        chainId: connectionResponse.chainId
-      })
+      // Publish unless the active account switched to a DIFFERENT one while the prompt was open. A
+      // same-account event (some wallets re-emit accountsChanged for the current account) must not
+      // suppress the publish; only a real switch (or disconnect) should. If it did switch away,
+      // return the identity to the caller but leave the context on the newer account.
+      const noAccountEvent = accountVersionRef.current === versionAtStart
+      const activeAccountStillOurs = lastEventAccountRef.current?.toLowerCase() === connectionResponse.account.toLowerCase()
+      if (noAccountEvent || activeAccountStillOurs) {
+        setState({
+          isLoading: false,
+          account: connectionResponse.account,
+          identity,
+          provider: connectionResponse.provider,
+          providerType: connectionResponse.providerType,
+          chainId: connectionResponse.chainId
+        })
+      }
 
       return identity
     })()
@@ -124,6 +139,11 @@ const ConnectionProvider = ({ children }: PropsWithChildren) => {
 
     const handleAccountsChanged = (accounts: string[]) => {
       const account = accounts[0]
+      // Record this event so an in-flight getIdentitySignature can tell a real account switch (its
+      // result must not clobber the new account) from a same-account re-emit (which it should still
+      // publish). undefined here means "disconnected", which is also a switch away from any account.
+      accountVersionRef.current += 1
+      lastEventAccountRef.current = account
       if (!account) {
         // Wallet disconnected — clear all connection state so downstream consumers
         // (e.g. RequestPage checking !provider || !providerType) detect the disconnect.

--- a/src/shared/connection/identity.ts
+++ b/src/shared/connection/identity.ts
@@ -63,7 +63,15 @@ async function generateIdentity(
  * (e.g. double-encoded hex keys).
  */
 function getCachedIdentity(address: string): AuthIdentity | undefined {
-  const cached = localStorageGetIdentity(address)
+  let cached: AuthIdentity | null
+  try {
+    // localStorageGetIdentity throws for a malformed address (it validates the key). A caller
+    // reacting to a wallet event may hand us a bad value, so treat that as "no cached identity"
+    // rather than letting the throw escape into an event listener.
+    cached = localStorageGetIdentity(address)
+  } catch {
+    return undefined
+  }
   if (!cached || !isValidIdentity(cached)) {
     return undefined
   }

--- a/src/shared/onboarding/markReturningUser.spec.ts
+++ b/src/shared/onboarding/markReturningUser.spec.ts
@@ -29,12 +29,12 @@ describe('markReturningUser', () => {
       })
     })
 
-    it('should track checkpoint for the wallet identifier', () => {
+    it('should track checkpoint for the wallet identifier lowercased so it correlates with other checkpoints', () => {
       markReturningUser(account)
       expect(trackCheckpoint).toHaveBeenCalledWith({
         checkpointId: 2,
         action: 'completed',
-        userIdentifier: account,
+        userIdentifier: '0xabc123',
         identifierType: 'wallet',
         wallet: '0xabc123'
       })

--- a/src/shared/onboarding/markReturningUser.ts
+++ b/src/shared/onboarding/markReturningUser.ts
@@ -20,7 +20,7 @@ export function markReturningUser(account: string) {
   trackCheckpoint({
     checkpointId: 2,
     action: 'completed',
-    userIdentifier: account,
+    userIdentifier: account.toLowerCase(),
     identifierType: 'wallet',
     wallet: account.toLowerCase()
   })

--- a/src/shared/profile.ts
+++ b/src/shared/profile.ts
@@ -1,5 +1,8 @@
 import { Profile } from 'dcl-catalyst-client/dist/client/specs/catalyst.schemas'
 
 export function isProfileComplete(profile: Profile) {
-  return profile.avatars?.[0]?.name !== undefined
+  // A profile is only complete when it has a non-empty name. Treating an empty or whitespace-only
+  // name (or null) as complete would let an effectively unnamed user skip onboarding.
+  const name = profile.avatars?.[0]?.name
+  return typeof name === 'string' && name.trim().length > 0
 }


### PR DESCRIPTION
## What

Fixes surfaced by a full review of the auth flows, spanning the signing surface, login/callback, connection state, and onboarding. No behavioral changes beyond the fixes below.

## Highlights

**Security**
- `signMethodGuard`: the sign-in impersonation guard only inspected plaintext, but `personal_sign` params arrive hex-encoded. A hex-encoded Decentraland login payload could pass the guard and then be signed as plaintext by the wallet, yielding an impersonating auth chain. The guard now hex-decodes params before the structural check (the sibling `extractSignaturePayload` already decoded the same param). Added regression tests.

**Signing / RequestPage**
- Never report a broadcast transaction as failed: once the wallet returns a hash/signature, a later outcome-delivery or tip-notification failure now shows completion instead of sending a **failed** outcome — which previously told the Explorer a confirmed tx was rejected and could prompt a double-submit (double tip / double transfer).
- Bounded the outcome-delivery POSTs with a timeout.
- `decodeNftTransferData` only decodes single-token transfers; batch variants (`uint256[]`) no longer yield a bogus `tokenId`.
- Removed an unreachable branch in `onContinueInApp` and the unused `walletInfo.chainId`.

**Login / callback**
- `AutoLoginRedirect` resolves Magic test-mode from the feature flag (and waits for flags to initialize), so both halves of the social OAuth handshake use the same Magic key.
- Cancelling a login (auto-login cancel / connection-modal close) aborts the in-flight flow, so a late-approved wallet prompt can't redirect or push the user into setup.
- Clock-sync "Continue" reuses the existing connection instead of reconnecting (no longer tears down the WalletConnect session).
- Email-login retry re-runs the post-verification steps instead of re-asking for an already-consumed OTP code (desktop + mobile).
- `CallbackPage` threads the freshly generated identity through instead of re-reading localStorage; `MobileCallbackPage` preserves the mobile session ids (`u`/`s`) on retry.
- Explorer-redirect detection matches on the URL pathname, not a substring.

**Connection state**
- `ConnectionProvider`: a stale identity signature can no longer clobber a newer account (guarded by an account-change version + last-event account, so a same-account re-emit still publishes).
- `getCachedIdentity` swallows the malformed-address throw.

**Onboarding / profile**
- Newsletter subscription now respects the marketing consent checkbox for inherited emails.
- Avatar deploy failure hides the preview overlay so the error / retry is visible.
- Timeouts on newsletter, referral, default-profile and fallback-redeploy fetches so a hung server can't strand the deploying spinner.
- Validate the fetched default profile before use; `isProfileComplete` requires a non-empty name; catalyst rotation retries 429/408; `markReturningUser` lowercases the wallet identifier; the guest link uses `set` (not `append`) and flushes its analytics event before navigating.

## Testing

- `tsc --noEmit` clean, `eslint` clean.
- Full Jest suite passes (811 tests). Added/updated tests for the impersonation-guard hex bypass, the `postIdentity` event gating, the outcome-POST timeouts, the newsletter opt-in, and `markReturningUser`.
- Note: a few `userEvent`-heavy suites are timing-sensitive and can hit the 15s Jest timeout under heavy machine load; they pass reliably in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
