### PR TITLE
fix: stop wiping WalletConnect storage on every connect and serialize connects

### DIFF
--- a/src/components/Pages/LoginPage/utils.spec.ts
+++ b/src/components/Pages/LoginPage/utils.spec.ts
@@ -118,7 +118,7 @@ describe('connectToProvider', () => {
       removeItemSpy.mockRestore()
     })
 
-    it('should clear the legacy WalletConnect deep-link choice without wiping the session storage', async () => {
+    it('should clear the legacy WalletConnect deep-link choice', async () => {
       await connectToProvider(ConnectionOptionType.WALLET_CONNECT)
 
       expect(removeItemSpy).toHaveBeenCalledWith('WALLETCONNECT_DEEPLINK_CHOICE')

--- a/src/components/Pages/LoginPage/utils.spec.ts
+++ b/src/components/Pages/LoginPage/utils.spec.ts
@@ -1,7 +1,16 @@
-import { SignInOptionsMode } from '../../Connection/Connection.types'
+import { connection } from 'decentraland-connect'
+import { ConnectionOptionType, SignInOptionsMode } from '../../Connection/Connection.types'
 import { FeatureFlagsKeys, SignInPrimaryOptionVariant } from '../../FeatureFlagsProvider/FeatureFlagsProvider.types'
 import type { FeatureFlagsVariants } from '../../FeatureFlagsProvider/FeatureFlagsProvider.types'
-import { getSignInOptionsMode } from './utils'
+import { connectToProvider, getSignInOptionsMode } from './utils'
+
+jest.mock('decentraland-connect', () => ({
+  connection: { connect: jest.fn() },
+  getConfiguration: jest.fn()
+}))
+
+// eslint-disable-next-line @typescript-eslint/unbound-method -- connection is fully mocked; connect is a jest.fn with no `this` binding
+const mockConnect = connection.connect as jest.Mock
 
 afterEach(() => {
   jest.clearAllMocks()
@@ -59,6 +68,60 @@ describe('getSignInOptionsMode', () => {
 
         expect(result).toBe(SignInOptionsMode.ONE)
       })
+    })
+  })
+})
+
+describe('connectToProvider', () => {
+  describe('when two connects for the same provider run concurrently', () => {
+    let resolveConnect: (value: { account: string; provider: object }) => void
+
+    beforeEach(() => {
+      mockConnect.mockImplementation(
+        () =>
+          new Promise(resolve => {
+            resolveConnect = resolve
+          })
+      )
+    })
+
+    it('should call connection.connect only once, sharing the in-flight attempt', async () => {
+      const first = connectToProvider(ConnectionOptionType.WALLET_CONNECT)
+      const second = connectToProvider(ConnectionOptionType.WALLET_CONNECT)
+
+      resolveConnect({ account: '0xabc', provider: {} })
+      await Promise.all([first, second])
+
+      expect(mockConnect).toHaveBeenCalledTimes(1)
+    })
+
+    it('should resolve both callers with the same connection data', async () => {
+      const first = connectToProvider(ConnectionOptionType.WALLET_CONNECT)
+      const second = connectToProvider(ConnectionOptionType.WALLET_CONNECT)
+
+      resolveConnect({ account: '0xabc', provider: {} })
+      const [firstResult, secondResult] = await Promise.all([first, second])
+
+      expect(firstResult).toBe(secondResult)
+    })
+  })
+
+  describe('when connecting to WalletConnect', () => {
+    let removeItemSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      removeItemSpy = jest.spyOn(Storage.prototype, 'removeItem')
+      mockConnect.mockResolvedValue({ account: '0xabc', provider: {} })
+    })
+
+    afterEach(() => {
+      removeItemSpy.mockRestore()
+    })
+
+    it('should clear the legacy WalletConnect deep-link choice without wiping the session storage', async () => {
+      await connectToProvider(ConnectionOptionType.WALLET_CONNECT)
+
+      expect(removeItemSpy).toHaveBeenCalledWith('WALLETCONNECT_DEEPLINK_CHOICE')
     })
   })
 })

--- a/src/components/Pages/LoginPage/utils.ts
+++ b/src/components/Pages/LoginPage/utils.ts
@@ -99,9 +99,11 @@ function requiresInjectedProvider(connectionOption: ConnectionOptionType): boole
   return fromConnectionOptionToProviderType(connectionOption) === ProviderType.INJECTED
 }
 
-// Coalesces concurrent connect attempts for the same provider (double-click, racing retry) so two
-// overlapping connection.connect() sequences can't corrupt each other's session/pairing. A different
-// provider is allowed to supersede — that's a genuine "user switched wallet" action.
+// Coalesces concurrent connect attempts for the SAME provider (double-click, racing retry) behind a
+// single in-flight promise, so a repeated click can't spawn a second overlapping connect for that
+// provider. A different provider is allowed to supersede (a genuine "user switched wallet" action);
+// cross-provider concurrency isn't serialized here and is instead prevented at the UI layer, where
+// the wallet-selection modal is modal (the user can't pick another wallet while one is pending).
 let inFlightConnect: { providerType: ProviderType; promise: Promise<ConnectionResponse> } | null = null
 
 async function connectToProvider(connectionOption: ConnectionOptionType): Promise<ConnectionResponse> {

--- a/src/components/Pages/LoginPage/utils.ts
+++ b/src/components/Pages/LoginPage/utils.ts
@@ -1,7 +1,7 @@
 import type { OAuthProvider } from '@magic-ext/oauth2'
 import { ProviderType } from '@dcl/schemas/dist/dapps/provider-type'
 import { Env } from '@dcl/ui-env'
-import { ConnectionResponse, WalletConnectV2Connector, connection, getConfiguration } from 'decentraland-connect'
+import { ConnectionResponse, connection, getConfiguration } from 'decentraland-connect'
 import { config } from '../../../modules/config'
 import { extractReferrerFromSearchParameters } from '../../../shared/locations'
 import { ConnectionOptionType, SignInOptionsMode } from '../../Connection'
@@ -99,6 +99,11 @@ function requiresInjectedProvider(connectionOption: ConnectionOptionType): boole
   return fromConnectionOptionToProviderType(connectionOption) === ProviderType.INJECTED
 }
 
+// Coalesces concurrent connect attempts for the same provider (double-click, racing retry) so two
+// overlapping connection.connect() sequences can't corrupt each other's session/pairing. A different
+// provider is allowed to supersede — that's a genuine "user switched wallet" action.
+let inFlightConnect: { providerType: ProviderType; promise: Promise<ConnectionResponse> } | null = null
+
 async function connectToProvider(connectionOption: ConnectionOptionType): Promise<ConnectionResponse> {
   const providerType = fromConnectionOptionToProviderType(connectionOption)
 
@@ -106,25 +111,39 @@ async function connectToProvider(connectionOption: ConnectionOptionType): Promis
     throw new Error('No wallet extension detected. Please install MetaMask or another Ethereum wallet.')
   }
 
-  // Clear stale WalletConnect/AppKit data to prevent session conflicts
-  if (providerType === ProviderType.WALLET_CONNECT || providerType === ProviderType.WALLET_CONNECT_V2) {
-    WalletConnectV2Connector.clearStorage()
-    localStorage.removeItem('WALLETCONNECT_DEEPLINK_CHOICE')
+  // Reuse an in-flight connect for the same provider instead of starting a second, overlapping one.
+  if (inFlightConnect && inFlightConnect.providerType === providerType) {
+    return inFlightConnect.promise
   }
 
-  let connectionData: ConnectionResponse
+  const promise = (async () => {
+    // Clear only WalletConnect v1's leftover deep-link choice, which can pin the mobile wallet
+    // chooser. WalletConnect session storage itself is owned by decentraland-connect, which
+    // validates and clears stale sessions on connect — wiping it here forced a fresh QR pairing on
+    // every attempt and prevented reusing the session established during the auth handoff.
+    if (providerType === ProviderType.WALLET_CONNECT_V2) {
+      localStorage.removeItem('WALLETCONNECT_DEEPLINK_CHOICE')
+    }
+
+    const connectionData = await connection.connect(providerType)
+    if (!connectionData.account || !connectionData.provider) {
+      throw new Error('Could not get provider')
+    }
+    return connectionData
+  })()
+
+  inFlightConnect = { providerType, promise }
   try {
-    connectionData = await connection.connect(providerType)
+    return await promise
   } catch (error) {
     console.error('Error connecting to provider', error)
     throw error
+  } finally {
+    // Only clear if this call still owns the slot (a different-provider connect may have replaced it).
+    if (inFlightConnect?.promise === promise) {
+      inFlightConnect = null
+    }
   }
-
-  if (!connectionData.account || !connectionData.provider) {
-    throw new Error('Could not get provider')
-  }
-
-  return connectionData
 }
 
 function isSocialLogin(connectionType: ConnectionOptionType): boolean {


### PR DESCRIPTION
## What

Two WalletConnect stability fixes in `connectToProvider`, from a cross-app review of how auth establishes the WalletConnect session that marketplace (and other dapps) later restore via same-origin `localStorage`.

## Changes

- **Stop wiping WalletConnect storage on every connect.** `connectToProvider` called `WalletConnectV2Connector.clearStorage()` before every WalletConnect connect, which destroyed any existing WC session and forced a fresh QR pairing on each attempt/retry — defeating reuse of the session established for the handoff. `decentraland-connect` already validates a restored session (a cheap `eth_chainId` probe) and clears it only when it's actually stale, so this manual pre-clear is removed. The legacy WalletConnect v1 `WALLETCONNECT_DEEPLINK_CHOICE` key is still cleared (it can pin the mobile wallet chooser).

- **Coalesce concurrent same-provider connects.** Added a module-level in-flight guard that coalesces concurrent `connectToProvider` calls for the *same* provider (double-click, racing retry) behind a single promise, so a repeated click can't spawn a second overlapping connect for that provider. A different provider still supersedes (a genuine "user switched wallet" action); cross-provider concurrency isn't serialized here — it's prevented at the UI layer, where the wallet-selection modal is modal.

## Testing

`tsc` clean, changed files lint-clean, LoginPage + connection suites pass. Added 3 tests: concurrent same-provider connects share one `connection.connect()` and resolve to the same data, and the WC path still clears the legacy deep-link key.

## Notes

- Independent of the open hardening PR — this branch is off `main` and only touches `LoginPage/utils.ts`.
- The deepest fix for the churn lives in `decentraland-connect` (companion PR decentraland/decentraland-connect#124 scopes the library's storage-clearing to WalletConnect-only disconnects). This change relies only on the stale-session validation already shipped in the version auth uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
