### PR TITLE
fix: always prompt the wallet chooser on an explicit WalletConnect click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "ajv": "8.12.0",
         "classnames": "2.3.2",
         "dcl-catalyst-client": "21.10.1",
-        "decentraland-connect": "^12.0.4",
+        "decentraland-connect": "^12.1.1",
         "decentraland-crypto-fetch": "^2.0.1",
         "decentraland-transactions": "^3.0.2",
         "decentraland-ui2": "^1.2.1",
@@ -14143,13 +14143,13 @@
       }
     },
     "node_modules/decentraland-connect": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-12.0.4.tgz",
-      "integrity": "sha512-j4R9shgNH6+oS0T5+phvLWn+OxepyXGbvejg0lM9ur8RxULwV39YfWsDLf16cfmuXYda5LvkJSH4fBK4rmlbYg==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-12.1.1.tgz",
+      "integrity": "sha512-+8eK55F3Gxs1cPe2v+Aw1SuSbXxVAqExRfrxC9ip5K5HgLXiiC5rYHFL56HOYjPklcUzw1+zne72S9HoLKNIXQ==",
       "dependencies": {
         "@dcl/schemas": "^22.1.0",
         "@magic-ext/oauth2": "15.3.2-canary.1040.22248562051.0",
-        "@reown/appkit": "^1.8.15",
+        "@reown/appkit": "^1.8.19",
         "@reown/appkit-adapter-wagmi": "^1.8.19",
         "@web3-react/fortmatic-connector": "^6.1.6",
         "@web3-react/injected-connector": "^6.0.7",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ajv": "8.12.0",
     "classnames": "2.3.2",
     "dcl-catalyst-client": "21.10.1",
-    "decentraland-connect": "^12.0.4",
+    "decentraland-connect": "^12.1.1",
     "decentraland-crypto-fetch": "^2.0.1",
     "decentraland-transactions": "^3.0.2",
     "decentraland-ui2": "^1.2.1",

--- a/src/components/Pages/LoginPage/utils.spec.ts
+++ b/src/components/Pages/LoginPage/utils.spec.ts
@@ -1,4 +1,4 @@
-import { connection } from 'decentraland-connect'
+import { WalletConnectV2Connector, connection } from 'decentraland-connect'
 import { ConnectionOptionType, SignInOptionsMode } from '../../Connection/Connection.types'
 import { FeatureFlagsKeys, SignInPrimaryOptionVariant } from '../../FeatureFlagsProvider/FeatureFlagsProvider.types'
 import type { FeatureFlagsVariants } from '../../FeatureFlagsProvider/FeatureFlagsProvider.types'
@@ -6,11 +6,14 @@ import { connectToProvider, getSignInOptionsMode } from './utils'
 
 jest.mock('decentraland-connect', () => ({
   connection: { connect: jest.fn() },
-  getConfiguration: jest.fn()
+  getConfiguration: jest.fn(),
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- mirrors the exported class name
+  WalletConnectV2Connector: { clearStorage: jest.fn() }
 }))
 
 // eslint-disable-next-line @typescript-eslint/unbound-method -- connection is fully mocked; connect is a jest.fn with no `this` binding
 const mockConnect = connection.connect as jest.Mock
+const mockClearStorage = WalletConnectV2Connector.clearStorage as jest.Mock
 
 afterEach(() => {
   jest.clearAllMocks()
@@ -122,6 +125,49 @@ describe('connectToProvider', () => {
       await connectToProvider(ConnectionOptionType.WALLET_CONNECT)
 
       expect(removeItemSpy).toHaveBeenCalledWith('WALLETCONNECT_DEEPLINK_CHOICE')
+    })
+
+    it('should clear the stored WalletConnect session so the wallet chooser is always prompted', async () => {
+      await connectToProvider(ConnectionOptionType.WALLET_CONNECT)
+
+      expect(mockClearStorage).toHaveBeenCalled()
+    })
+
+    it('should clear the stored session before connecting, so the session cannot be reused', async () => {
+      await connectToProvider(ConnectionOptionType.WALLET_CONNECT)
+
+      expect(mockClearStorage.mock.invocationCallOrder[0]).toBeLessThan(mockConnect.mock.invocationCallOrder[0])
+    })
+
+    it('should clear the stored session again on a subsequent connect, so a second click re-prompts', async () => {
+      await connectToProvider(ConnectionOptionType.WALLET_CONNECT)
+      await connectToProvider(ConnectionOptionType.WALLET_CONNECT)
+
+      expect(mockClearStorage).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('when connecting to MetaMask Mobile', () => {
+    beforeEach(() => {
+      mockConnect.mockResolvedValue({ account: '0xabc', provider: {} })
+    })
+
+    it('should clear the stored WalletConnect session, since it also pairs over WalletConnect', async () => {
+      await connectToProvider(ConnectionOptionType.METAMASK_MOBILE)
+
+      expect(mockClearStorage).toHaveBeenCalled()
+    })
+  })
+
+  describe('when connecting to a provider that does not use WalletConnect', () => {
+    beforeEach(() => {
+      mockConnect.mockResolvedValue({ account: '0xabc', provider: {} })
+    })
+
+    it('should not clear the stored WalletConnect session', async () => {
+      await connectToProvider(ConnectionOptionType.COINBASE)
+
+      expect(mockClearStorage).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/components/Pages/LoginPage/utils.ts
+++ b/src/components/Pages/LoginPage/utils.ts
@@ -1,7 +1,7 @@
 import type { OAuthProvider } from '@magic-ext/oauth2'
 import { ProviderType } from '@dcl/schemas/dist/dapps/provider-type'
 import { Env } from '@dcl/ui-env'
-import { ConnectionResponse, connection, getConfiguration } from 'decentraland-connect'
+import { ConnectionResponse, WalletConnectV2Connector, connection, getConfiguration } from 'decentraland-connect'
 import { config } from '../../../modules/config'
 import { extractReferrerFromSearchParameters } from '../../../shared/locations'
 import { ConnectionOptionType, SignInOptionsMode } from '../../Connection'
@@ -119,12 +119,23 @@ async function connectToProvider(connectionOption: ConnectionOptionType): Promis
   }
 
   const promise = (async () => {
-    // Clear only WalletConnect v1's leftover deep-link choice, which can pin the mobile wallet
-    // chooser. WalletConnect session storage itself is owned by decentraland-connect, which
-    // validates and clears stale sessions on connect — wiping it here forced a fresh QR pairing on
-    // every attempt and prevented reusing the session established during the auth handoff.
     if (providerType === ProviderType.WALLET_CONNECT_V2) {
+      // Clear WalletConnect v1's leftover deep-link choice, which can pin the mobile wallet chooser.
       localStorage.removeItem('WALLETCONNECT_DEEPLINK_CHOICE')
+
+      // Force a fresh pairing on every explicit WalletConnect click. decentraland-connect's
+      // `activate()` reuses a restored session whenever it is still alive and, on that branch, never
+      // opens the AppKit modal — so clicking WalletConnect would silently reconnect the previously
+      // paired wallet and give a user who wants to sign in with a *different* wallet no way to
+      // choose one. Clearing the session here is what guarantees `activate()` takes its
+      // "not connected" branch and prompts.
+      //
+      // This is not redundant with the library's own stale-session handling: that only clears a
+      // session it can prove is dead, whereas an explicit click must re-prompt even when the
+      // session is perfectly alive. It also only runs on a user-initiated connect — automatic
+      // restores go through `connection.tryPreviousConnection()` and never reach this function, so
+      // the session reuse the handoff depends on is untouched.
+      WalletConnectV2Connector.clearStorage()
     }
 
     const connectionData = await connection.connect(providerType)


### PR DESCRIPTION
## What

Clicking **WalletConnect** stopped opening the wallet chooser once a WalletConnect session was present in `localStorage`: the click silently reconnected the previously paired wallet, so a user who wanted to sign in with a *different* wallet had no way to choose one. Clicking the button should always prompt.

Also lands the `decentraland-connect` bump to 12.1.1, which was prepared alongside #436 but never merged.

## Root cause

`decentraland-connect`'s `activate()` only opens the AppKit modal on one branch:

```ts
if (isConnected) {                           // AppKit restored a session reporting status 'connected'
  if (!alive) { clear; re-init; open modal } // re-prompts only when the session is provably dead
} else {
  await this.openModalAndWaitForConnection() // the only path that prompts
}
```

#436 removed the `WalletConnectV2Connector.clearStorage()` call that ran before every WalletConnect connect. That call was the only thing guaranteeing `isConnected === false`, so removing it made session reuse the default for explicit clicks — and the reuse branch never opens the modal.

#436 treated that reuse as the goal ("prevented reusing the session established during the auth handoff"). That is in direct conflict with the requirement that the button always prompt, so this reverses that specific part while keeping the rest of #436.

## Changes

- **Restore the pre-connect clear**, scoped to `WALLET_CONNECT_V2` and to the user-initiated path. Automatic restores go through `connection.tryPreviousConnection()` and never reach `connectToProvider()`, so the session reuse the handoff depends on is untouched. #436's in-flight coalescing guard is kept, so a double-click still cannot open two modals. MetaMask Mobile maps to `WALLET_CONNECT_V2` and is covered by the same branch.

  The comment on that line explains the intent, because it reads as redundant with the library's stale-session handling and was removed once on exactly that basis. It is not redundant: the library clears only a session it can prove is dead, whereas an explicit click must re-prompt even when the session is perfectly alive.

- **Bump `decentraland-connect` 12.0.4 → 12.1.1**, picking up decentraland/decentraland-connect#124: WC-scoped storage clearing on disconnect, `close()` dropping the shared AppKit singleton, `activate()` re-acquiring the AppKit instance after a stale-session retry, RPC routed through the configured Decentraland endpoints, and the connector storing the chain the wallet actually connected on.

  12.1.1 also raises the declared `@reown/appkit` floor from `^1.8.15` to `^1.8.19` to match `@reown/appkit-adapter-wagmi`. Both already resolved to 1.8.19 here, so the dependency tree is unchanged and the lockfile edit is limited to the `decentraland-connect` entry.

  Worth noting: `main` declared `^12.0.4` while local installs were already resolving 12.1.1, so local and CI disagreed on the version of the library that owns the WC session. This closes that gap. The fix above works on either version — `clearStorage` nulls `sharedAppKit` in both, which matters because a stale in-memory AppKit singleton would otherwise still report `connected` after `localStorage` was wiped.

## Testing

`tsc` clean, 821 tests pass across 45 suites, changed files lint-clean.

Added 5 tests: the stored session is cleared on a WalletConnect click, cleared *before* `connection.connect` (so it cannot be reused), cleared again on a subsequent click, cleared for MetaMask Mobile, and **not** cleared for providers that do not use WalletConnect.

Verified in a browser against the dev server: with `wc@2:*`, `@appkit*` and the legacy deep-link key seeded in `localStorage`, clicking WalletConnect clears them and opens the AppKit modal (`w3m-modal` at `display: block` / `opacity: 1`, shadow root containing `wui-card role="alertdialog" aria-modal="true"`), with no AppKit errors in the console.

One limit on that check: the seeded session is synthetic, so AppKit would likely have discarded it and prompted regardless. It confirms the clear executes on click and that prompting works end-to-end, but it does not reproduce the original silent reuse, which needs a live relay session with a real paired wallet. The root cause rests on the code path above. Reviewers should confirm against a real wallet that previously reproduced the issue.

## Notes

- decentraland/decentraland-connect#124 notes that `auth` and `marketplace` should pin the same published version, since they are the writer and reader of the shared same-origin WC session. This covers `auth` only; `marketplace` is still on whatever it had.