### PR TITLE
fix: forward the invite referrer through wallet auto-login

### DIFF
--- a/src/components/Pages/LoginPage/AutoLoginRedirect.spec.tsx
+++ b/src/components/Pages/LoginPage/AutoLoginRedirect.spec.tsx
@@ -1,0 +1,163 @@
+/* eslint-disable import/order */
+import { render, waitFor } from '@testing-library/react'
+
+const mockEnsureProfile = jest.fn()
+const mockRedirect = jest.fn()
+const mockConnectToProvider = jest.fn()
+const mockConnectToSocialProvider = jest.fn()
+const mockGetIdentitySignature = jest.fn()
+const mockCheckClockSync = jest.fn()
+const mockNavigate = jest.fn()
+let mockSkipSetup = false
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate
+}))
+
+jest.mock('@dcl/hooks', () => ({
+  useTranslation: () => ({ t: (id: string) => id })
+}))
+
+jest.mock('decentraland-ui2', () => ({
+  Button: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+  CircularProgress: () => <div data-testid="circular-progress" />
+}))
+
+jest.mock('../../../hooks/useAnalytics', () => ({
+  useAnalytics: () => ({ trackLoginClick: jest.fn(), trackLoginSuccess: jest.fn() })
+}))
+
+jest.mock('../../../hooks/useEnsureProfile', () => ({
+  useEnsureProfile: () => ({ ensureProfile: mockEnsureProfile })
+}))
+
+jest.mock('../../../hooks/usePostLoginRedirect', () => ({
+  usePostLoginRedirect: () => ({
+    redirect: mockRedirect,
+    redirectTo: 'https://decentraland.org/download',
+    skipSetup: mockSkipSetup
+  })
+}))
+
+jest.mock('../../../shared/connection', () => ({
+  useCurrentConnectionData: () => ({ getIdentitySignature: mockGetIdentitySignature })
+}))
+
+jest.mock('../../../shared/onboarding/markReturningUser', () => ({
+  markReturningUser: jest.fn()
+}))
+
+jest.mock('../../../shared/onboarding/trackCheckpoint', () => ({
+  trackCheckpoint: jest.fn()
+}))
+
+jest.mock('../../../shared/utils/clockSync', () => ({
+  checkClockSync: () => mockCheckClockSync()
+}))
+
+jest.mock('../../../shared/utils/errorHandler', () => ({
+  handleError: jest.fn()
+}))
+
+jest.mock('../../AnimatedBackground', () => ({
+  AnimatedBackground: () => <div data-testid="animated-background" />
+}))
+
+jest.mock('../../ConnectionModal/ConnectionLayout.styled', () => ({
+  ConnectionContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ConnectionTitle: ({ children }: { children: React.ReactNode }) => <h1>{children}</h1>,
+  DecentralandLogo: () => <div data-testid="logo" />,
+  ProgressContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
+jest.mock('../../Pages/CallbackPage/CallbackPage.styled', () => ({
+  Container: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Wrapper: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
+jest.mock('../../Pages/LoginErrorPage', () => ({
+  LoginErrorPage: () => <div data-testid="login-error-page" />
+}))
+
+jest.mock('./utils', () => ({
+  connectToProvider: (type: string) => mockConnectToProvider(type),
+  connectToSocialProvider: (...args: unknown[]) => mockConnectToSocialProvider(...args),
+  isMagicTestMode: () => false,
+  isSocialLogin: () => false
+}))
+
+import { AutoLoginRedirect } from './AutoLoginRedirect'
+import { ConnectionOptionType } from '../../Connection/Connection.types'
+
+const REFERRER = '0xd9b96b5dc720fc52bede1ec3b40a930e15f70ddd'
+const ACCOUNT = '0x1234567890abcdef1234567890abcdef12345678'
+
+const originalLocation = window.location
+const originalEthereum = (window as { ethereum?: unknown }).ethereum
+
+const setSearch = (search: string) => {
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: new URL(`http://localhost/auth/login?${search}`)
+  })
+}
+
+beforeEach(() => {
+  ;(window as { ethereum?: unknown }).ethereum = {}
+  mockSkipSetup = false
+  mockConnectToProvider.mockResolvedValue({ account: ACCOUNT })
+  mockGetIdentitySignature.mockResolvedValue({ authChain: [] })
+  mockCheckClockSync.mockResolvedValue(true)
+  mockEnsureProfile.mockResolvedValue(null)
+})
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', { writable: true, value: originalLocation })
+  ;(window as { ethereum?: unknown }).ethereum = originalEthereum
+  jest.resetAllMocks()
+})
+
+describe('when auto-logging in with a wallet and the URL carries a referrer', () => {
+  it('should forward the referrer to ensureProfile so setup can record the referral', async () => {
+    setSearch(`loginMethod=metamask&referrer=${REFERRER}&redirectTo=https%3A%2F%2Fdecentraland.org%2Fdownload`)
+
+    render(<AutoLoginRedirect connectionType={ConnectionOptionType.METAMASK} />)
+
+    await waitFor(() => expect(mockEnsureProfile).toHaveBeenCalled())
+    expect(mockEnsureProfile).toHaveBeenCalledWith(ACCOUNT, expect.anything(), expect.objectContaining({ referrer: REFERRER }))
+  })
+})
+
+describe('when the URL carries no referrer', () => {
+  it('should pass a null referrer', async () => {
+    setSearch('loginMethod=metamask&redirectTo=https%3A%2F%2Fdecentraland.org%2Fdownload')
+
+    render(<AutoLoginRedirect connectionType={ConnectionOptionType.METAMASK} />)
+
+    await waitFor(() => expect(mockEnsureProfile).toHaveBeenCalled())
+    expect(mockEnsureProfile).toHaveBeenCalledWith(ACCOUNT, expect.anything(), expect.objectContaining({ referrer: null }))
+  })
+})
+
+describe('when the referrer param is not a valid address', () => {
+  it('should drop it instead of forwarding a bogus value', async () => {
+    setSearch('loginMethod=metamask&referrer=not-an-address')
+
+    render(<AutoLoginRedirect connectionType={ConnectionOptionType.METAMASK} />)
+
+    await waitFor(() => expect(mockEnsureProfile).toHaveBeenCalled())
+    expect(mockEnsureProfile).toHaveBeenCalledWith(ACCOUNT, expect.anything(), expect.objectContaining({ referrer: null }))
+  })
+})
+
+describe('when the redirect targets an Explorer request', () => {
+  it('should skip the profile check entirely', async () => {
+    setSearch(`loginMethod=metamask&referrer=${REFERRER}&redirectTo=%2Fauth%2Frequests%2Fabc`)
+
+    render(<AutoLoginRedirect connectionType={ConnectionOptionType.METAMASK} />)
+
+    await waitFor(() => expect(mockRedirect).toHaveBeenCalled())
+    expect(mockEnsureProfile).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/Pages/LoginPage/AutoLoginRedirect.tsx
+++ b/src/components/Pages/LoginPage/AutoLoginRedirect.tsx
@@ -8,7 +8,7 @@ import { usePostLoginRedirect } from '../../../hooks/usePostLoginRedirect'
 import { ConnectionType } from '../../../modules/analytics/types'
 import { useCurrentConnectionData } from '../../../shared/connection'
 import { isUserRejectedTransaction } from '../../../shared/errors'
-import { locations } from '../../../shared/locations'
+import { extractReferrerFromSearchParameters, locations } from '../../../shared/locations'
 import { markReturningUser } from '../../../shared/onboarding/markReturningUser'
 import { trackCheckpoint } from '../../../shared/onboarding/trackCheckpoint'
 import { checkClockSync } from '../../../shared/utils/clockSync'
@@ -50,6 +50,11 @@ export const AutoLoginRedirect = ({ connectionType }: Props) => {
   // Raw redirectTo for connectToSocialProvider (needs the original, unsanitized value
   // because Magic encodes it in customData for the OAuth callback round-trip)
   const rawRedirectTo = useMemo(() => new URLSearchParams(window.location.search).get('redirectTo') ?? undefined, [])
+
+  // Referrer from the invite link (`/invite/:name` sends it as `?referrer=0x…`).
+  // QuickSetup is the only place that posts the referral, so it has to survive
+  // the hop into setup or the referral is never recorded.
+  const referrer = useMemo(() => extractReferrerFromSearchParameters(new URLSearchParams(window.location.search)), [])
 
   const handleCancel = useCallback(() => {
     // Navigate to login page without loginMethod — shows full login UI.
@@ -124,7 +129,7 @@ export const AutoLoginRedirect = ({ connectionType }: Props) => {
       if (!isExplorerRedirect && !skipSetupRef.current && connectionData.account) {
         const profile = await ensureProfile(connectionData.account, freshIdentity, {
           redirectTo,
-          referrer: null,
+          referrer,
           navigateOptions: { replace: true }
         })
         if (!profile) return
@@ -150,6 +155,7 @@ export const AutoLoginRedirect = ({ connectionType }: Props) => {
     isSocial,
     isMagicTest,
     rawRedirectTo,
+    referrer,
     redirectTo,
     trackLoginClick,
     trackLoginSuccess,


### PR DESCRIPTION
`AutoLoginRedirect` passed `referrer: null` hardcoded into `ensureProfile`, so the wallet auto-login path (`/auth/login?loginMethod=<wallet>`) dropped the invite referrer on the hop into setup. QuickSetup is the only place that posts to `/referral-progress`, and it reads the referrer off the URL, so a visitor arriving from `decentraland.org/invite/:name` and auto-logging in with a wallet was never recorded as a referral.

`DesktopCallbackPage` already forwards it correctly for the social/OAuth path. This aligns the wallet path with the same helper (`extractReferrerFromSearchParameters`), which also keeps the `EthAddress` validation, so a malformed `?referrer=` still resolves to null instead of being forwarded.

Added `AutoLoginRedirect.spec.tsx`, which had no coverage: referrer forwarded, no referrer, invalid referrer, and the Explorer-request path that skips the profile check.

Verified: prettier, `fix:code`, `lint:pkg`, `npm run build`, full suite (45 suites / 802 tests).

Separate and not addressed here: on mobile, `useSkipSetup` returns true from the ios/android target config, so `ensureProfile` never runs and the visitor never reaches QuickSetup, meaning no referral is recorded at all regardless of this fix. Since the referral POST only fires for users without a complete profile, moving it out of QuickSetup needs a call on whether the referral service accepts a POST for an already-existing account. Filed as an issue rather than guessed at here.
