### PR TITLE
fix: detect the wallet rejection web3-react throws during login

### DIFF
--- a/src/shared/errors.spec.ts
+++ b/src/shared/errors.spec.ts
@@ -1,0 +1,68 @@
+import { isUserRejectedTransaction } from './errors'
+
+/**
+ * `@web3-react/injected-connector` throws this when the user dismisses the wallet prompt during
+ * `connection.connect()`. It carries no EIP-1193 `code`, and its `name` is assigned from
+ * `this.constructor.name`, which minifies to a single letter in production — so the message is the
+ * only stable signal.
+ */
+class Web3ReactUserRejectedRequestError extends Error {
+  constructor() {
+    super()
+    this.name = this.constructor.name
+    this.message = 'The user rejected the request.'
+  }
+}
+
+describe('isUserRejectedTransaction', () => {
+  describe('when the user dismisses the wallet prompt while connecting', () => {
+    it('should detect the error web3-react throws, which carries no code', () => {
+      expect(isUserRejectedTransaction(new Web3ReactUserRejectedRequestError())).toBe(true)
+    })
+
+    it('should detect it after minification has rewritten the error name', () => {
+      const minified = new Web3ReactUserRejectedRequestError()
+      minified.name = 'n'
+
+      expect(isUserRejectedTransaction(minified)).toBe(true)
+    })
+  })
+
+  describe('when the wallet reports the rejection through an EIP-1193 code', () => {
+    it('should detect viem UserRejectedRequestError', () => {
+      expect(isUserRejectedTransaction({ code: 4001, message: 'User rejected the request.' })).toBe(true)
+    })
+
+    it('should detect the ethers v6 rejection', () => {
+      expect(isUserRejectedTransaction({ code: 'ACTION_REJECTED', message: 'user rejected action' })).toBe(true)
+    })
+
+    it('should detect the decentraland-transactions rejection', () => {
+      expect(isUserRejectedTransaction({ code: 'user_denied', message: 'User denied message signature' })).toBe(true)
+    })
+
+    it('should detect the rejection decentraland-transactions misclassifies as unknown', () => {
+      expect(isUserRejectedTransaction({ code: 'unknown', message: 'User rejected the request.' })).toBe(true)
+    })
+  })
+
+  describe('when the failure is not a user rejection', () => {
+    it('should not match a locked wallet', () => {
+      expect(isUserRejectedTransaction(new Error('There was an error unlocking your wallet.'))).toBe(false)
+    })
+
+    it('should not match an unrelated rpc failure', () => {
+      expect(isUserRejectedTransaction({ code: -32603, message: 'Internal error' })).toBe(false)
+    })
+
+    it('should not match an arbitrary error', () => {
+      expect(isUserRejectedTransaction(new Error('Could not get provider'))).toBe(false)
+    })
+
+    it('should not match non-object values', () => {
+      expect(isUserRejectedTransaction(null)).toBe(false)
+      expect(isUserRejectedTransaction(undefined)).toBe(false)
+      expect(isUserRejectedTransaction('The user rejected the request.')).toBe(false)
+    })
+  })
+})

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -66,6 +66,9 @@ function isMagicExtensionError(error: unknown): error is { code: string; rawMess
  *    is exactly "User denied message signature". Viem uses a different message
  *    ("User rejected the request.") so the library falls through to code 'unknown',
  *    requiring a message-based fallback.
+ * - @web3-react/injected-connector's UserRejectedRequestError (no code at all)
+ *    Thrown by connection.connect() during login, reached through decentraland-connect.
+ *    Matched by message ("The user rejected the request.") since it exposes nothing else.
  */
 function isUserRejectedTransaction(error: unknown): boolean {
   if (error === null || typeof error !== 'object') return false
@@ -82,6 +85,13 @@ function isUserRejectedTransaction(error: unknown): boolean {
   // because it only checks for "User denied message signature" (ethers-era message).
   // Detect via the preserved viem message.
   if (code === 'unknown' && isErrorWithMessage(error) && error.message === 'User rejected the request.') return true
+
+  // @web3-react/injected-connector throws its own UserRejectedRequestError from
+  // connection.connect(), which reaches us through decentraland-connect's ConnectionManager.
+  // It carries no EIP-1193 code at all, and its name comes from `this.constructor.name`, which
+  // minification rewrites to a single letter in production — leaving the message as the only
+  // stable signal. Note the wording differs from viem's by a leading article.
+  if (isErrorWithMessage(error) && error.message === 'The user rejected the request.') return true
 
   return false
 }


### PR DESCRIPTION
Fixes AUTH-SITE-13P

## What

[AUTH-SITE-13P](https://decentraland.sentry.io/issues/AUTH-SITE-13P) is the largest issue in this project — **533 events across 203 users**. It is a user cancelling the wallet prompt, but it surfaces two ways it should not:

1. **UX**: on the auto-login path the user lands on a hard error screen instead of the `WalletErrorModal`.
2. **Noise**: the cancellation is reported to Sentry as an application error.

Both call sites already intend to handle this. `AutoLoginRedirect.tsx:141` catches the rejection to navigate to `?walletError=rejected` precisely so `LoginPage` can show the modal, and `LoginPage.tsx:271` skips reporting outright. Neither branch ever fired.

## Why it was missed

`connection.connect()` goes through `decentraland-connect`'s `ConnectionManager` into `@web3-react/injected-connector`, which throws **its own** `UserRejectedRequestError` — a different class from viem's and ethers':

```
decentraland-connect/dist/ConnectionManager.js:31  ConnectionManager.connect
@web3-react/injected-connector/dist/injected-connector.esm.js:307
    throw new UserRejectedRequestError();
```

It carries **no EIP-1193 `code` at all**, so `4001` / `ACTION_REJECTED` / `user_denied` all miss. The message fallback missed too, on both of its conditions: it requires `code === 'unknown'`, and it compares against viem's `"User rejected the request."` while web3-react's wording is `"The user rejected the request."` — a leading article apart.

Matching on the message is the only signal available. The class sets its name from `this.constructor.name`, which minification rewrites to a single letter in production — which is why Sentry groups these under `n:`.

## Testing

`src/shared/errors.ts` had no spec. Added `src/shared/errors.spec.ts` (10 tests):

- The two new cases — the web3-react error as thrown, and again with the name minified to `n`.
- Regression guards for the paths that already worked: viem `4001`, ethers `ACTION_REJECTED`, decentraland-transactions `user_denied`, and the `unknown` + viem-message fallback.
- Negatives: a locked wallet, an unrelated RPC failure, an arbitrary error, and non-object values.

Written test-first: the two new cases failed against the old predicate while the other eight passed, which is what confirmed the diagnosis.

Full suite: 47 suites, 819 tests passing. `tsc --noEmit`, `eslint` and `prettier --check` clean.

## Scope

Only the detection predicate changes; no call site is touched. Both existing branches start working on their own once the shape is recognised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
