### PR TITLE
fix: keep expected wallet conditions out of Sentry

### DIFF
--- a/src/shared/errors.spec.ts
+++ b/src/shared/errors.spec.ts
@@ -1,4 +1,4 @@
-import { isUserRejectedTransaction } from './errors'
+import { isExpectedWalletError, isUserRejectedTransaction } from './errors'
 
 /**
  * `@web3-react/injected-connector` throws this when the user dismisses the wallet prompt during
@@ -63,6 +63,57 @@ describe('isUserRejectedTransaction', () => {
       expect(isUserRejectedTransaction(null)).toBe(false)
       expect(isUserRejectedTransaction(undefined)).toBe(false)
       expect(isUserRejectedTransaction('The user rejected the request.')).toBe(false)
+    })
+  })
+})
+
+describe('isExpectedWalletError', () => {
+  describe('when the wallet is locked and decentraland-connect gives up', () => {
+    it('should classify it as expected', () => {
+      const lockedWallet = new Error('There was an error unlocking your wallet. Please be sure your wallet is unlocked and try again.')
+      lockedWallet.name = 'ErrorUnlockingWallet'
+
+      expect(isExpectedWalletError(lockedWallet)).toBe(true)
+    })
+  })
+
+  describe('when the wallet already has a prompt open for this origin', () => {
+    it('should classify the EIP-1193 resource-unavailable code as expected', () => {
+      const alreadyPending = {
+        code: -32002,
+        message: "Request of type 'wallet_requestPermissions' already pending for origin https://decentraland.org. Please wait."
+      }
+
+      expect(isExpectedWalletError(alreadyPending)).toBe(true)
+    })
+  })
+
+  describe('when the user dismisses the WalletConnect modal', () => {
+    it('should classify it as expected, since it arrives as a bare Error', () => {
+      expect(isExpectedWalletError(new Error('User closed the modal without connecting'))).toBe(true)
+    })
+  })
+
+  describe('when the failure is a genuine fault', () => {
+    it('should not classify an internal rpc error as expected', () => {
+      expect(isExpectedWalletError({ code: -32603, message: 'Internal error' })).toBe(false)
+    })
+
+    it('should not classify a missing provider as expected', () => {
+      expect(isExpectedWalletError(new Error('Could not get provider'))).toBe(false)
+    })
+
+    it('should not classify an arbitrary error carrying a wallet-ish name as expected', () => {
+      const other = new Error('boom')
+      other.name = 'SomeOtherError'
+
+      expect(isExpectedWalletError(other)).toBe(false)
+    })
+
+    it('should not classify non-object values as expected', () => {
+      expect(isExpectedWalletError(null)).toBe(false)
+      expect(isExpectedWalletError(undefined)).toBe(false)
+      expect(isExpectedWalletError('User closed the modal without connecting')).toBe(false)
     })
   })
 })

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -96,5 +96,40 @@ function isUserRejectedTransaction(error: unknown): boolean {
   return false
 }
 
+/**
+ * Wallet and connector conditions that are not application faults: the wallet is locked, it
+ * already has a prompt open for this origin, or the user dismissed the connection modal. The
+ * login genuinely fails for the user — so these are still logged and tracked — but there is
+ * nothing here for us to fix.
+ *
+ * User rejections are detected separately by {@link isUserRejectedTransaction}, which some call
+ * sites also use to drive navigation and so must stay distinguishable.
+ */
+function isExpectedWalletError(error: unknown): boolean {
+  if (error === null || typeof error !== 'object') return false
+
+  // decentraland-connect's InjectedConnector rejects with this when the injected wallet will not
+  // unlock. The login screen already keys its ERROR_LOCKED_WALLET state off the same name.
+  if (isErrorWithName(error) && error.name === 'ErrorUnlockingWallet') return true
+
+  // EIP-1193 "resource unavailable". MetaMask uses it for "a request of this type is already
+  // pending for this origin", which clears as soon as the user answers the prompt already open.
+  if ((error as { code: unknown }).code === -32002) return true
+
+  // decentraland-connect's WalletConnectV2Connector rejects with a bare Error when the user closes
+  // the AppKit modal, so the message is the only signal it leaves.
+  if (isErrorWithMessage(error) && error.message === 'User closed the modal without connecting') return true
+
+  return false
+}
+
 export type { RPCError }
-export { isErrorWithMessage, isErrorWithName, isRpcError, isMagicRpcError, isMagicExtensionError, isUserRejectedTransaction }
+export {
+  isErrorWithMessage,
+  isErrorWithName,
+  isRpcError,
+  isMagicRpcError,
+  isMagicExtensionError,
+  isUserRejectedTransaction,
+  isExpectedWalletError
+}

--- a/src/shared/utils/errorHandler.spec.ts
+++ b/src/shared/utils/errorHandler.spec.ts
@@ -1,4 +1,5 @@
 import { captureException } from '@sentry/react'
+import { trackEvent } from './analytics'
 import { handleError } from './errorHandler'
 
 jest.mock('@sentry/react', () => ({
@@ -91,6 +92,47 @@ describe('handleError → captureException', () => {
           url: 'https://decentraland.org/auth/login'
         })
       )
+    })
+  })
+})
+
+describe('handleError → expected wallet conditions', () => {
+  const mockTrackEvent = trackEvent as jest.Mock
+
+  beforeEach(() => {
+    mockCaptureException.mockClear()
+    mockTrackEvent.mockClear()
+  })
+
+  const expectedConditions: [string, unknown][] = [
+    ['a locked wallet', Object.assign(new Error('There was an error unlocking your wallet.'), { name: 'ErrorUnlockingWallet' })],
+    ['a wallet prompt already pending', { code: -32002, message: "Request of type 'wallet_requestPermissions' already pending" }],
+    ['the WalletConnect modal being dismissed', new Error('User closed the modal without connecting')]
+  ]
+
+  it.each(expectedConditions)('should not report %s to Sentry', (_case, error) => {
+    handleError(error, 'context')
+
+    expect(mockCaptureException).not.toHaveBeenCalled()
+  })
+
+  it.each(expectedConditions)('should still track %s, since the login did fail for the user', (_case, error) => {
+    handleError(error, 'context')
+
+    expect(mockTrackEvent).toHaveBeenCalled()
+  })
+
+  it('should return the message so callers can still render it', () => {
+    const message = handleError(new Error('User closed the modal without connecting'), 'context')
+
+    expect(message).toBe('User closed the modal without connecting')
+  })
+
+  describe('and the failure is a genuine fault', () => {
+    it('should still be reported', () => {
+      handleError({ code: -32603, message: 'Internal error' }, 'context')
+
+      expect(mockCaptureException).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/shared/utils/errorHandler.ts
+++ b/src/shared/utils/errorHandler.ts
@@ -1,7 +1,7 @@
 import { captureException } from '@sentry/react'
 import { TrackingEvents } from '../../modules/analytics/types'
 import { DeploymentError } from '../../modules/profile/errors'
-import { isErrorWithMessage } from '../errors'
+import { isErrorWithMessage, isExpectedWalletError } from '../errors'
 import { trackEvent } from './analytics'
 import { ErrorContext, HandleErrorOptions, SentryExtra } from './errorHandler.types'
 
@@ -77,13 +77,19 @@ const handleError = (error: unknown, context: string, options?: HandleErrorOptio
     console.error(`${context}:`, errorMessage)
   }
 
-  const deploymentExtra = getDeploymentErrorExtra(error)
-  const { error: normalised, originalShape } = normaliseError(error)
+  // Expected wallet conditions (locked wallet, a prompt already open, a dismissed modal) still
+  // reach the console and the analytics event below — the login really did fail for the user —
+  // but they are not faults of ours, so they stay out of Sentry. Left unfiltered they were the
+  // bulk of this project's volume and buried the failures worth acting on.
+  if (!isExpectedWalletError(error)) {
+    const deploymentExtra = getDeploymentErrorExtra(error)
+    const { error: normalised, originalShape } = normaliseError(error)
 
-  captureException(normalised, {
-    tags: options?.sentryTags,
-    extra: { ...deploymentExtra, ...(originalShape ?? {}), ...options?.sentryExtra }
-  })
+    captureException(normalised, {
+      tags: options?.sentryTags,
+      extra: { ...deploymentExtra, ...(originalShape ?? {}), ...options?.sentryExtra }
+    })
+  }
 
   if (!options?.skipTracking) {
     const trackingEvent = (options?.trackingEvent as TrackingEvents) || TrackingEvents.LOGIN_ERROR


### PR DESCRIPTION
Fixes AUTH-SITE-4, AUTH-SITE-HV, AUTH-SITE-16F, AUTH-SITE-16D

Follows #455, which handled the user-rejection case.

## What

Three connector conditions account for roughly **4.7k events across ~390 users**, and none is a fault of ours:

| Issue | Events (lifetime) | Users | Origin |
|---|---:|---:|---|
| [AUTH-SITE-4](https://decentraland.sentry.io/issues/AUTH-SITE-4) | 3707 | 199 | `decentraland-connect/connectors/InjectedConnector.js:14` — wallet will not unlock |
| [AUTH-SITE-HV](https://decentraland.sentry.io/issues/AUTH-SITE-HV) | 882 | 102 | `decentraland-connect/connectors/WalletConnectV2Connector.js:251` — modal dismissed |
| [16F](https://decentraland.sentry.io/issues/AUTH-SITE-16F) + [16D](https://decentraland.sentry.io/issues/AUTH-SITE-16D) | 159 | 89 | MetaMask, EIP-1193 `-32002` — a prompt is already open for this origin |

The login does fail for the user in each case. But a locked wallet, a dismissed modal and an already-open prompt are user-side states, not defects, and at this volume they were burying the failures worth acting on.

## How

Adds `isExpectedWalletError` to `src/shared/errors.ts` and gates **only** the `captureException` call on it inside `handleError`.

Console logging and the analytics event are deliberately left in place. These are genuine funnel failures even though they are not defects, so the `LOGIN_ERROR` tracking that feeds funnel analysis is unaffected — the change is strictly about what reaches Sentry.

Detection notes:

- **Locked wallet** keys off the same `name` the login screen already uses to pick `ERROR_LOCKED_WALLET` (`LoginPage.tsx:282`, `MobileAuthPage.tsx:128,309`), so detection and presentation stay consistent.
- **Dismissed modal** arrives as a bare `Error` with no code or distinctive name, so the message is the only available signal.
- **`-32002`** is the EIP-1193 resource-unavailable code; MetaMask uses it for the already-pending case, which clears as soon as the user answers the prompt they already have open.

User rejections stay in `isUserRejectedTransaction`, separate on purpose: call sites also branch on that one to navigate to `?walletError=rejected`, so the two have to remain distinguishable.

## Testing

- `src/shared/errors.spec.ts` — the three conditions classify as expected; an internal RPC error, a missing provider, an unrelated named error and non-object values do not.
- `src/shared/utils/errorHandler.spec.ts` — for each of the three: not reported to Sentry, **still tracked**, and the message still returned to the caller. Plus a regression guard that a genuine fault (`-32603`) is still reported.

Written test-first; the three "should not report" cases failed against the current handler while the tracking and genuine-fault guards passed from the start.

Full suite: 47 suites, 834 tests passing. `tsc --noEmit`, `eslint` and `prettier --check` clean.

## Risk

If any of these three ever indicates a real defect, it will now be invisible in Sentry — the analytics event is the remaining signal. The narrow matches (exact name, exact message, exact code) are deliberate so the blast radius stays limited to these shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
