### PR TITLE
fix: say what is actually wrong with unusable transaction params

### DIFF
--- a/src/components/Pages/RequestPage/RequestPage.tsx
+++ b/src/components/Pages/RequestPage/RequestPage.tsx
@@ -40,6 +40,7 @@ import { sendTipNotification } from '../../../shared/notifications'
 import { identifyUser, trackEvent } from '../../../shared/utils/analytics'
 import { handleError } from '../../../shared/utils/errorHandler'
 import { FeatureFlagsContext } from '../../FeatureFlagsProvider/FeatureFlagsProvider.types'
+import { getTransactionToAddress } from './transactionParams'
 import { MANATransferData, NFTTransferData, SignaturePayload, SimulationState, TransferType } from './types'
 import {
   buildSendTransactionSimulationPayload,
@@ -836,12 +837,7 @@ export const RequestPage = () => {
         })
       } else {
         const chainId = getMetaTransactionChainId()
-        const txParams = requestRef.current?.params?.[0] as Record<string, unknown> | undefined
-        const toAddress = txParams?.to as string | undefined
-
-        if (!toAddress) {
-          throw new Error(`Contract address not found in transaction parameters. Received params: ${JSON.stringify(txParams ?? null)}`)
-        }
+        const toAddress = getTransactionToAddress(requestRef.current?.params)
 
         // Check if this contract will use meta transactions, reusing the prefetch result for the
         // same contract when available to avoid repeating the lookup.

--- a/src/components/Pages/RequestPage/transactionParams.spec.ts
+++ b/src/components/Pages/RequestPage/transactionParams.spec.ts
@@ -1,0 +1,62 @@
+import { getTransactionToAddress } from './transactionParams'
+
+describe('getTransactionToAddress', () => {
+  describe('when the params carry a well-formed transaction', () => {
+    it('should return the destination address', () => {
+      const params = [{ from: '0xabc', to: '0xdef', value: '0x0', data: '0x' }]
+
+      expect(getTransactionToAddress(params)).toBe('0xdef')
+    })
+  })
+
+  describe('when the caller serialised the transaction instead of sending an object', () => {
+    // The shape actually seen in production (AUTH-SITE-17J): params[0] arrived as a JSON string,
+    // so reading `.to` off it silently yielded undefined and the old message blamed a missing
+    // contract address while printing a payload that plainly contained one.
+    let params: unknown[]
+
+    beforeEach(() => {
+      params = [JSON.stringify({ from: '0x7ec943', to: '0x7ec943', value: '0x0de0b6b3a7640000', data: '0x' })]
+    })
+
+    it('should name the type it actually received', () => {
+      expect(() => getTransactionToAddress(params)).toThrow(/received string/)
+    })
+
+    it('should not claim the destination address is missing', () => {
+      expect(() => getTransactionToAddress(params)).not.toThrow(/missing a "to" address/)
+    })
+
+    it('should include the payload so the sender can be identified', () => {
+      expect(() => getTransactionToAddress(params)).toThrow(/0x0de0b6b3a7640000/)
+    })
+  })
+
+  describe('when the params are unusable in other ways', () => {
+    it('should reject an array in place of the transaction object', () => {
+      expect(() => getTransactionToAddress([['0xdef']])).toThrow(/received array/)
+    })
+
+    it('should reject a missing params list', () => {
+      expect(() => getTransactionToAddress(undefined)).toThrow(/received undefined/)
+    })
+
+    it('should reject an empty params list', () => {
+      expect(() => getTransactionToAddress([])).toThrow(/received undefined/)
+    })
+
+    it('should reject a null transaction object', () => {
+      expect(() => getTransactionToAddress([null])).toThrow(/received null/)
+    })
+  })
+
+  describe('when the transaction object has no usable destination', () => {
+    it('should say the address is missing rather than blaming the shape', () => {
+      expect(() => getTransactionToAddress([{ from: '0xabc', data: '0x' }])).toThrow(/missing a "to" address/)
+    })
+
+    it('should reject a non-string address instead of failing later on it', () => {
+      expect(() => getTransactionToAddress([{ to: 42 }])).toThrow(/missing a "to" address/)
+    })
+  })
+})

--- a/src/components/Pages/RequestPage/transactionParams.ts
+++ b/src/components/Pages/RequestPage/transactionParams.ts
@@ -1,0 +1,29 @@
+const describeType = (value: unknown): string => (Array.isArray(value) ? 'array' : value === null ? 'null' : typeof value)
+
+/**
+ * Reads the destination address out of an `eth_sendTransaction` request's params.
+ *
+ * Deliberately throws instead of coercing. This feeds the transaction-approval flow, so params
+ * that do not arrive in the expected shape must stop the approval rather than be reconstructed
+ * from whatever the caller sent.
+ *
+ * The two failure modes are reported separately because they point at different culprits: a first
+ * param that is not an object means the caller serialised its payload, while a well-formed object
+ * without a `to` means the request itself is incomplete. Conflating them produced a message that
+ * blamed a missing contract address while printing a payload that visibly contained one.
+ */
+export function getTransactionToAddress(params: unknown[] | undefined): string {
+  const [txParams] = params ?? []
+
+  if (txParams === null || typeof txParams !== 'object' || Array.isArray(txParams)) {
+    throw new Error(`Transaction parameters must be an object, received ${describeType(txParams)}: ${JSON.stringify(txParams ?? null)}`)
+  }
+
+  const toAddress = (txParams as Record<string, unknown>).to
+
+  if (typeof toAddress !== 'string' || toAddress.length === 0) {
+    throw new Error(`Transaction parameters are missing a "to" address: ${JSON.stringify(txParams)}`)
+  }
+
+  return toAddress
+}


### PR DESCRIPTION
Refs [AUTH-SITE-17J](https://decentraland.sentry.io/issues/AUTH-SITE-17J)

## What

The approve path reported:

```
Contract address not found in transaction parameters.
Received params: "{\"from\":\"0x7ec943…\",\"to\":\"0x7eC943…\",\"value\":\"0x0de0b6b3a7640000\",\"data\":\"0x\"}"
```

It says the address is missing while printing a payload that visibly contains one. The contradiction is in the escaping: `JSON.stringify` produced a **quoted, escaped string**, which means `params[0]` arrived as a serialised JSON string rather than an object — so `.to` read off it yielded `undefined`.

The message sends whoever reads it hunting for a missing address that is right there in the payload. It cost real time to untangle, and the next occurrence would cost it again.

## How

Splits the two failure modes, which have different causes and different culprits:

| Params | Message |
|---|---|
| `["{\"to\":\"0x…\"}"]` | `Transaction parameters must be an object, received string: …` |
| `[["0x…"]]` / `[null]` / `[]` | `…received array` / `…received null` / `…received undefined` |
| `[{ from: "0x…" }]` | `Transaction parameters are missing a "to" address: …` |

A first param that is not an object points at the caller serialising its payload; a well-formed object without a `to` points at an incomplete request.

## What this deliberately does not do

**Behaviour is unchanged** — both cases still throw and still stop the approval.

Coercing a serialised payload back into transaction parameters (i.e. `JSON.parse`-ing it and proceeding) is intentionally *not* done. This is the signing surface, and reconstructing a transaction from whatever the caller sent is not a decision this guard should make. Determining whether the client serialises the params or something in the auth-server round-trip does is a separate investigation; this change just makes the next occurrence diagnosable enough to answer it.

One small strictness change: `to` must now be a string. Previously a non-string truthy value passed the check and failed a few lines later on `toAddress.toLowerCase()`.

## Why a new module

`getTransactionToAddress` lives in `transactionParams.ts` rather than `RequestPage/utils.ts` because `utils.ts` transitively imports the Connection components (`utils.ts` → `LoginPage/utils` → `components/Connection` → `decentraland-ui2`). Putting it there would mean `RequestPage.spec`'s `./utils` mock needs an entry for it, and a stub would have to restate the validation — which is testing the mock. In its own module the component tests exercise the real implementation with no mock at all.

## Testing

`transactionParams.spec.ts`, 10 tests written test-first — including the exact shape from production (a stringified payload), each unusable-params variant, and the genuinely-missing-`to` case. Notably one asserts the message does **not** claim the address is missing when the real problem is the shape.

Full suite: 48 suites, 844 tests passing. `tsc --noEmit`, `eslint` and `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
