### PR TITLE
fix: keep a blocked Intercom widget out of Sentry

### DIFF
--- a/src/components/Intercom/IntercomWidget.spec.ts
+++ b/src/components/Intercom/IntercomWidget.spec.ts
@@ -1,0 +1,87 @@
+import { IntercomWidget } from './IntercomWidget'
+
+const INJECT_TIMEOUT_MS = 10000
+
+type UnreportableError = Error & { skipReporting?: boolean }
+
+/**
+ * Awaits a promise expected to reject and hands back the rejection. Fails loudly if it resolves,
+ * so a regression that silently stops rejecting cannot pass as an absent `skipReporting`.
+ */
+async function rejectionOf(promise: Promise<unknown>): Promise<UnreportableError> {
+  try {
+    await promise
+  } catch (thrown) {
+    return thrown as UnreportableError
+  }
+
+  throw new Error('Expected the injection to reject, but it resolved')
+}
+
+describe('IntercomWidget.inject', () => {
+  let widget: IntercomWidget
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    widget = IntercomWidget.getInstance()
+    widget.init('an-app-id')
+  })
+
+  const insertedScript = () => document.body.querySelector('script') as HTMLScriptElement
+
+  describe('when the widget script is blocked before it can load', () => {
+    let error: UnreportableError
+
+    beforeEach(async () => {
+      const injecting = widget.inject()
+      insertedScript().dispatchEvent(new Event('error'))
+      error = await rejectionOf(injecting)
+    })
+
+    it('should reject explaining the script could not be loaded', () => {
+      expect(error.message).toBe('Failed to load the Intercom widget script')
+    })
+
+    // The widget is blocked by ad/tracking blockers, privacy browsers and ISP filtering. Nothing
+    // is broken on our side and the site works without it, so the rejection must not be reported.
+    it('should flag the rejection so it stays out of Sentry', () => {
+      expect(error.skipReporting).toBe(true)
+    })
+  })
+
+  describe('when the widget script never loads', () => {
+    let error: UnreportableError
+
+    beforeEach(async () => {
+      jest.useFakeTimers()
+      const injecting = widget.inject()
+      jest.advanceTimersByTime(INJECT_TIMEOUT_MS)
+      error = await rejectionOf(injecting)
+      jest.useRealTimers()
+    })
+
+    it('should reject explaining the load timed out', () => {
+      expect(error.message).toBe('Timed out loading the Intercom widget script')
+    })
+
+    it('should flag the rejection so it stays out of Sentry', () => {
+      expect(error.skipReporting).toBe(true)
+    })
+  })
+
+  describe('when a blocked injection is retried', () => {
+    it('should attempt a fresh injection rather than replaying the cached failure', async () => {
+      const firstAttempt = widget.inject()
+      insertedScript().dispatchEvent(new Event('error'))
+      await firstAttempt.catch(() => undefined)
+
+      document.body.innerHTML = ''
+      const secondAttempt = widget.inject()
+
+      expect(insertedScript()).not.toBeNull()
+
+      insertedScript().dispatchEvent(new Event('error'))
+      await secondAttempt.catch(() => undefined)
+    })
+  })
+})

--- a/src/components/Intercom/IntercomWidget.ts
+++ b/src/components/Intercom/IntercomWidget.ts
@@ -6,6 +6,18 @@ const intercomWindow = window as unknown as IntercomWindow
 // or offline script surfaces an error to the caller instead of hanging forever.
 const INJECT_TIMEOUT_MS = 10000
 
+/**
+ * Builds a rejection that `handleError` will not report (see `shouldSkipReporting` in
+ * shared/utils/errorHandler).
+ *
+ * The widget script is routinely blocked by ad and tracking blockers, privacy-focused browsers
+ * and ISP-level filtering: the observed failures span every browser and every release, and a
+ * third of them come from a single country. Nothing is broken on our side, and the site is fully
+ * usable without support chat — so the caller still gets a rejection to act on, but it does not
+ * belong in Sentry.
+ */
+const unreportable = (message: string): Error => Object.assign(new Error(message), { skipReporting: true })
+
 class IntercomWidget {
   private _appId: string | undefined
   private _settings: IntercomSettings | undefined
@@ -68,7 +80,7 @@ class IntercomWidget {
 
       // Ensure the promise always settles so a blocked/offline script rejects
       // (surfacing to the caller's catch) instead of hanging forever.
-      const timeoutId = setTimeout(() => reject(new Error('Timed out loading the Intercom widget script')), INJECT_TIMEOUT_MS)
+      const timeoutId = setTimeout(() => reject(unreportable('Timed out loading the Intercom widget script')), INJECT_TIMEOUT_MS)
 
       script.addEventListener(
         'load',
@@ -82,7 +94,7 @@ class IntercomWidget {
         'error',
         () => {
           clearTimeout(timeoutId)
-          reject(new Error('Failed to load the Intercom widget script'))
+          reject(unreportable('Failed to load the Intercom widget script'))
         },
         true
       )


### PR DESCRIPTION
Fixes [AUTH-SITE-17T](https://decentraland.sentry.io/issues/AUTH-SITE-17T), [AUTH-SITE-17V](https://decentraland.sentry.io/issues/AUTH-SITE-17V)

## What

Loading the support widget fails **124 times in 30 days across 96 users**, split between a timeout (17T) and a hard load error (17V).

I checked whether this was our integration breaking rather than the environment, and the distribution answers it:

- **Every browser**: Chrome, Edge, Chrome Mobile, Opera, Samsung Internet, Huawei Browser, Vivo, HeyTap, Firefox, Mobile Safari, and the Norton browser.
- **Every release**: 4.21.0, 5.0.0 and 5.0.1 alike — no regression point.
- **Concentrated geographically**: Vietnam alone is 40 of 124, then a long thin tail across 14+ countries.

That is ad/tracking blockers, privacy-focused browsers and ISP-level filtering. A broken `appId` or URL would fail uniformly in proportion to traffic and would start at a specific release; neither holds.

The site is fully usable without support chat, and the caller already treats this as non-actionable — `Intercom.tsx` passes `skipTracking: true`. Only Sentry was still receiving it.

## How

Both rejections are now built through a small `unreportable()` helper that flags them with `skipReporting`, which the existing gate in `handleError` (`shouldSkipReporting`) already honours — the same mechanism `shared/auth/errors.ts` and `thirdweb/emailAuth.ts` use.

The caller still receives a rejection to act on, and the cached-promise reset that allows a later `inject()` to retry is untouched.

## Testing

`IntercomWidget.spec.ts` is new — the module had no tests. Five cases: both rejection paths (message and flag), and the cached-promise reset that lets a retry insert a fresh script.

The spec uses a `rejectionOf()` helper rather than `.catch(e => e)` so that a regression which stops rejecting fails loudly instead of quietly presenting as a missing `skipReporting`.

Full suite: 48 suites, 839 tests passing. `tsc --noEmit`, `eslint` and `prettier --check` clean.

## Risk

If the integration genuinely breaks — a wrong `appId` would 404 and fire the same `error` event — it is now silent in Sentry, and `shouldSkipReporting` returns before the `console.error` too, so there is no local signal either. The browser network tab still shows it immediately, and a real misconfiguration would present as support chat missing for everyone right after a deploy rather than as a thin trickle across dozens of countries.

If that trade is unwanted, the alternative is to keep reporting but sample it, or to report only when the failure rate crosses a threshold. I did not build either, since the current signal has no consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
