### PR TITLE
fix: always name the login provider on login success

### DIFF
--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -2,6 +2,7 @@
 import { useCallback } from 'react'
 import { ConnectionOptionType } from '../components/Connection'
 import { AvatarShape } from '../components/Pages/AvatarSetupPage/AvatarSetupPage.types'
+import { consumeLoginMethod, rememberLoginMethod } from '../modules/analytics/loginMethod'
 import { ClickEvents, ConnectionType, TrackingEvents } from '../modules/analytics/types'
 import { TRACKING_DELAY } from '../shared/constants'
 import { wait } from '../shared/time'
@@ -15,21 +16,26 @@ interface ClickData {
 
 export const useAnalytics = () => {
   const trackLoginClick = useCallback((data: { method?: ConnectionOptionType; type: ConnectionType | string }) => {
+    // Remembered here, not in each flow, so the success event can name the provider even when the
+    // login finishes on a different page load. Doing it at the single point every flow already goes
+    // through is what keeps the guarantee from depending on anyone remembering it.
+    rememberLoginMethod(data.method)
     trackEvent(TrackingEvents.LOGIN_CLICK, data)
   }, [])
 
   const trackLoginSuccess = useCallback(
     async (data: { ethAddress?: string; type: ConnectionType | string; method?: ConnectionOptionType }) => {
-      // `method` is currently only sent from the mobile flow. On desktop every login is preceded by
-      // a user click in this app, so LOGIN_CLICK already carries `method` and the LOGIN_SUCCESS that
-      // follows can be correlated by session — `method` on success is redundant there. On mobile,
-      // entries through a deep link from the partner app are automatic (no click in this app), so
-      // there is no preceding LOGIN_CLICK to attribute the provider, and `method` has to ride on
-      // LOGIN_SUCCESS itself.
+      // `method` names the provider the user actually logged in with, and it has to be on this event:
+      // correlating success back to the preceding click by session only works for someone querying raw
+      // Segment, and it breaks entirely for social logins, which return on a fresh page load after the
+      // OAuth redirect. Callers that know the method pass it (the mobile deep-link entry has no click
+      // to fall back on); everyone else gets it from the click that started this attempt.
+      const method = data.method ?? consumeLoginMethod()
+
       await trackWithDelay(TrackingEvents.LOGIN_SUCCESS, {
         eth_address: data.ethAddress,
         type: data.type,
-        ...(data.method && { method: data.method })
+        ...(method && { method })
       })
 
       if (data.ethAddress) {

--- a/src/modules/analytics/loginMethod.spec.ts
+++ b/src/modules/analytics/loginMethod.spec.ts
@@ -1,0 +1,87 @@
+import { ConnectionOptionType } from '../../components/Connection'
+import { consumeLoginMethod, rememberLoginMethod } from './loginMethod'
+
+const STORAGE_KEY = 'dcl_auth_last_login_method'
+const AN_HOUR = 60 * 60 * 1000
+
+describe('loginMethod', () => {
+  afterEach(() => {
+    localStorage.clear()
+    jest.restoreAllMocks()
+  })
+
+  describe('when a method was remembered', () => {
+    beforeEach(() => {
+      rememberLoginMethod(ConnectionOptionType.METAMASK)
+    })
+
+    it('should return it', () => {
+      expect(consumeLoginMethod()).toBe(ConnectionOptionType.METAMASK)
+    })
+
+    it('should return it only once, so a later login without a click of its own is not attributed to it', () => {
+      consumeLoginMethod()
+      expect(consumeLoginMethod()).toBeUndefined()
+    })
+  })
+
+  describe('when nothing was remembered', () => {
+    it('should return undefined', () => {
+      expect(consumeLoginMethod()).toBeUndefined()
+    })
+  })
+
+  describe('when remembering without a method', () => {
+    it('should store nothing, so an earlier value is not overwritten by a guest login', () => {
+      rememberLoginMethod(ConnectionOptionType.GOOGLE)
+      rememberLoginMethod(undefined)
+      expect(consumeLoginMethod()).toBe(ConnectionOptionType.GOOGLE)
+    })
+  })
+
+  describe('when the remembered method is older than the TTL', () => {
+    beforeEach(() => {
+      jest.spyOn(Date, 'now').mockReturnValue(0)
+      rememberLoginMethod(ConnectionOptionType.GOOGLE)
+      jest.spyOn(Date, 'now').mockReturnValue(AN_HOUR + 1)
+    })
+
+    it('should discard it', () => {
+      expect(consumeLoginMethod()).toBeUndefined()
+    })
+  })
+
+  describe('when the remembered method is within the TTL', () => {
+    beforeEach(() => {
+      jest.spyOn(Date, 'now').mockReturnValue(0)
+      rememberLoginMethod(ConnectionOptionType.GOOGLE)
+      jest.spyOn(Date, 'now').mockReturnValue(AN_HOUR - 1)
+    })
+
+    it('should return it, because a social login round trip can take minutes', () => {
+      expect(consumeLoginMethod()).toBe(ConnectionOptionType.GOOGLE)
+    })
+  })
+
+  describe('when the stored value is not the shape this module writes', () => {
+    beforeEach(() => {
+      localStorage.setItem(STORAGE_KEY, 'not json')
+    })
+
+    it('should return undefined instead of throwing', () => {
+      expect(consumeLoginMethod()).toBeUndefined()
+    })
+  })
+
+  describe('when storage is unavailable', () => {
+    beforeEach(() => {
+      jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError')
+      })
+    })
+
+    it('should not throw, because losing the method must never break a login', () => {
+      expect(() => rememberLoginMethod(ConnectionOptionType.METAMASK)).not.toThrow()
+    })
+  })
+})

--- a/src/modules/analytics/loginMethod.ts
+++ b/src/modules/analytics/loginMethod.ts
@@ -1,0 +1,66 @@
+import { ConnectionOptionType } from '../../components/Connection'
+
+const STORAGE_KEY = 'dcl_auth_last_login_method'
+
+/**
+ * How long a remembered method stays valid.
+ *
+ * A social login leaves this app entirely (OAuth redirect) and comes back on a fresh page load, so the
+ * value has to outlive the navigation. An hour is generous for that round trip and short enough that a
+ * method left behind by an abandoned attempt cannot be attributed to an unrelated login days later.
+ * It also matches the window the warehouse already uses when it back-fills `method` from the preceding
+ * click, so both sides agree on what counts as "the same attempt".
+ */
+const TTL_MS = 60 * 60 * 1000
+
+type StoredMethod = {
+  method: string
+  at: number
+}
+
+/**
+ * Record the provider the user just chose, so the success event can name it even when the login
+ * completes on a different page load.
+ *
+ * Called from the click tracking rather than from each login flow: every login starts with a click we
+ * already track with `method`, so wiring it here is what makes the guarantee hold for flows nobody
+ * remembered to update — including the ones that redirect away.
+ *
+ * localStorage rather than sessionStorage on purpose: some providers return in a new tab, which starts
+ * with an empty sessionStorage and would lose the value. The TTL is what keeps localStorage safe.
+ */
+function rememberLoginMethod(method?: ConnectionOptionType | string): void {
+  if (!method) return
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ method, at: Date.now() } satisfies StoredMethod))
+  } catch {
+    // Private mode or a full quota. Losing the method degrades analytics, never the login.
+  }
+}
+
+/**
+ * The method remembered for the login attempt in flight, or undefined when there is none to trust.
+ *
+ * Reads once and clears, so a stale value cannot be attributed to a later login that had no click of
+ * its own (an auto-login, a restored session). Anything older than the TTL is discarded for the same
+ * reason.
+ */
+function consumeLoginMethod(): string | undefined {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return undefined
+
+    localStorage.removeItem(STORAGE_KEY)
+
+    const stored = JSON.parse(raw) as Partial<StoredMethod>
+    if (typeof stored?.method !== 'string' || typeof stored?.at !== 'number') return undefined
+    if (Date.now() - stored.at > TTL_MS) return undefined
+
+    return stored.method
+  } catch {
+    return undefined
+  }
+}
+
+export { consumeLoginMethod, rememberLoginMethod }


### PR DESCRIPTION
Closes decentraland/monodata#319

## Changes

`Login Success` only carried `method` when a caller happened to pass it, which in practice was the mobile deep-link flow. Every other login left it empty, so the warehouse could not break logins down by provider for roughly 75% of successes (web3 paths: ~4.5% fill).

- `modules/analytics/loginMethod`: remembers the provider the user picked, with a one-hour TTL.
- `useAnalytics.trackLoginClick` records it; `trackLoginSuccess` falls back to it when the caller passes nothing.

Wiring it into the click tracking rather than into each login flow is what makes the guarantee hold: every login already starts with a click we track with `method`, including the flows that redirect away and come back on a fresh page load, where an in-memory value would be gone. Callers that know the method still win — the mobile deep-link entry has no click to fall back on and keeps passing it explicitly.

`localStorage` rather than `sessionStorage` because some providers return in a new tab, which starts with an empty `sessionStorage`. The TTL is what keeps that safe, and it matches the one-hour window the warehouse already uses when it back-fills `method` from the preceding click, so both sides agree on what counts as the same attempt. The value is read once and cleared, so a login with no click of its own (auto-login, restored session) cannot inherit a stale provider.

Analytics never breaks the login: storage failures are swallowed, and a missing method just omits the property as before.

## Test plan

- [x] `loginMethod` unit tests: round trip, read-once, TTL boundary on both sides, malformed stored value, storage throwing
- [x] `src/modules/analytics` + `src/hooks` — 141 tests pass
- [x] Login page, callback, mobile auth and mobile callback specs — 32 tests pass
- [x] `npm run lint`, `npm run build`
- [ ] Verify in staging that `Login Success` carries `method` for MetaMask (web3) and for Google (web2, after the OAuth redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6DBtjjVZy42puhtLnKiAZ